### PR TITLE
Places shared storage configs into bos_components config/install dir.

### DIFF
--- a/docroot/modules/custom/bos_components/config/install/field.storage.comment.comment_body.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.comment.comment_body.yml
@@ -1,0 +1,21 @@
+uuid: 98041a08-a371-4828-9901-c81a66dd6822
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - text
+_core:
+  default_config_hash: swYoCch_hY8QO5uwr4FURplfnUCUlpPB4idF8WGVCpw
+id: comment.comment_body
+field_name: comment_body
+entity_type: comment
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_additional_information.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_additional_information.yml
@@ -1,0 +1,19 @@
+uuid: 99d18283-16fe-4de7-ba2b-604b8a9146f6
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_additional_information
+field_name: field_additional_information
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_background_image.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_background_image.yml
@@ -1,0 +1,24 @@
+uuid: 2570036b-a50c-40a1-9cb3-5f0293dd2716
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_background_image
+field_name: field_background_image
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: city-hall-building-background
+      label: 'City Hall Building'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_column_configuration.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_column_configuration.yml
@@ -1,0 +1,30 @@
+uuid: 9bd6afa5-d612-469d-9810-be8606a27e02
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_column_configuration
+field_name: field_column_configuration
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: col_half
+      label: '1/2 column + 1/2 column'
+    -
+      value: col_two_one_third
+      label: '2/3 column + 1/3 column'
+    -
+      value: col_one_one_third
+      label: '1/3 column + 2/3 column'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_column_description.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_column_description.yml
@@ -1,0 +1,19 @@
+uuid: fe662846-f36d-4e3f-91a3-9f20127678b9
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_column_description
+field_name: field_column_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_column_title.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_column_title.yml
@@ -1,0 +1,21 @@
+uuid: 5341fa75-5d9e-4d46-aa17-9ba3c58dcd54
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_column_title
+field_name: field_column_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_columns.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_columns.yml
@@ -1,0 +1,20 @@
+uuid: dafa3f4e-6adf-42e1-a167-7454cf0940c7
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_columns
+field_name: field_columns
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_components.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_components.yml
@@ -1,0 +1,20 @@
+uuid: a72594c0-8edf-4fc2-ad35-386cdec707e7
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_components
+field_name: field_components
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_contact.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_contact.yml
@@ -1,0 +1,20 @@
+uuid: 3517c8b7-faee-44d6-8aea-e0da89112279
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_contact
+field_name: field_contact
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_contacts.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_contacts.yml
@@ -1,0 +1,20 @@
+uuid: baaf507b-c2eb-4ce4-8a29-ceba8a98cfac
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_contacts
+field_name: field_contacts
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_date.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_date.yml
@@ -1,0 +1,20 @@
+uuid: d2bec4df-da81-4016-beff-05f63bdd07bd
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - paragraphs
+id: paragraph.field_date
+field_name: field_date
+entity_type: paragraph
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_document.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_document.yml
@@ -1,0 +1,23 @@
+uuid: 6f5f1ed6-467a-4143-8bc8-aa04abda56ad
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - paragraphs
+id: paragraph.field_document
+field_name: field_document
+entity_type: paragraph
+type: file
+settings:
+  display_default: false
+  display_field: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_document_id.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_document_id.yml
@@ -1,0 +1,21 @@
+uuid: bd8738f8-9971-4be3-944e-27f6d17b838d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_document_id
+field_name: field_document_id
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_extra_info.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_extra_info.yml
@@ -1,0 +1,21 @@
+uuid: b1f3f0c4-031a-4d6b-908e-b3fd4ac50a16
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_extra_info
+field_name: field_extra_info
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_featured_item.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_featured_item.yml
@@ -1,0 +1,20 @@
+uuid: d5a9de4e-8f74-41cd-bd30-06eacd3fdce3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_featured_item
+field_name: field_featured_item
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_featured_post.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_featured_post.yml
@@ -1,0 +1,20 @@
+uuid: 60b01f8f-0b87-40b6-92d5-80a046ce4ede
+langcode: und
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_featured_post
+field_name: field_featured_post
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_first_name.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_first_name.yml
@@ -1,0 +1,21 @@
+uuid: bb92db12-b70f-412a-8946-6368df8a9391
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_first_name
+field_name: field_first_name
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_grid_link.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_grid_link.yml
@@ -1,0 +1,20 @@
+uuid: 09125391-f5c3-44f7-9628-a4cec9e3800e
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_grid_link
+field_name: field_grid_link
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_grid_links.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_grid_links.yml
@@ -1,0 +1,20 @@
+uuid: 1092b5ab-7eed-458b-ba78-910eea29df5a
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_grid_links
+field_name: field_grid_links
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_header.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_header.yml
@@ -1,0 +1,21 @@
+uuid: 6b2ffb20-289b-477e-9c44-61d6d092fb50
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_header
+field_name: field_header
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_hide_title_bar.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_hide_title_bar.yml
@@ -1,0 +1,18 @@
+uuid: 1c9dc87d-3df8-4317-a4a5-d6a3e21d997a
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hide_title_bar
+field_name: field_hide_title_bar
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_hours_icon.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_hours_icon.yml
@@ -1,0 +1,24 @@
+uuid: 71acaa3d-09cb-44c5-9ea2-6ad415eee066
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_hours_icon
+field_name: field_hours_icon
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: icon-time
+      label: Time
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_icon.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_icon.yml
@@ -1,0 +1,26 @@
+uuid: b517e6f4-fda1-428e-8339-df8773797f96
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_icon
+field_name: field_icon
+entity_type: paragraph
+type: image
+settings:
+  default_image:
+    uuid: ''
+  uri_scheme: public
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_image.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_image.yml
@@ -1,0 +1,26 @@
+uuid: a50b364e-6477-42c6-a394-91b43fea7c6e
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_image
+field_name: field_image
+entity_type: paragraph
+type: image
+settings:
+  default_image:
+    uuid: ''
+  uri_scheme: public
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_last_name.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_last_name.yml
@@ -1,0 +1,21 @@
+uuid: f82f7113-6833-463c-8d30-aaf24d214cbe
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_last_name
+field_name: field_last_name
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_left_column.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_left_column.yml
@@ -1,0 +1,19 @@
+uuid: 7a131642-795a-4714-8599-2df0cd3349a1
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_left_column
+field_name: field_left_column
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_link.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_link.yml
@@ -1,0 +1,20 @@
+uuid: 2d8ba197-6254-40d5-a69e-7f142d1446b4
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_link
+field_name: field_link
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_links.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_links.yml
@@ -1,0 +1,20 @@
+uuid: ae1c3f5e-fd4c-4e3a-b8c4-c3ed253175f3
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_links
+field_name: field_links
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_list.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_list.yml
@@ -1,0 +1,21 @@
+uuid: d2c6c651-78b0-46bd-890d-c413ad6a7b3a
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - viewfield
+    - views
+id: paragraph.field_list
+field_name: field_list
+entity_type: paragraph
+type: viewfield
+settings:
+  target_type: view
+module: viewfield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_list_links.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_list_links.yml
@@ -1,0 +1,20 @@
+uuid: 9b79a79b-1643-4d04-a3e3-d62b288f025a
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_list_links
+field_name: field_list_links
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_message.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_message.yml
@@ -1,0 +1,19 @@
+uuid: 838ed364-eaad-42c2-a67d-82b635961ca6
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_message
+field_name: field_message
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_middle_column.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_middle_column.yml
@@ -1,0 +1,19 @@
+uuid: 9a089757-e562-494a-98f4-09fda16fca90
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_middle_column
+field_name: field_middle_column
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_operation_hours.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_operation_hours.yml
@@ -1,0 +1,20 @@
+uuid: cee78c39-4853-451b-84bf-71b5ef75033e
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_operation_hours
+field_name: field_operation_hours
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_people.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_people.yml
@@ -1,0 +1,20 @@
+uuid: 62df6cd3-9fd4-4043-915b-1165525715ff
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_people
+field_name: field_people
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_person.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_person.yml
@@ -1,0 +1,20 @@
+uuid: d3478c44-d99d-4753-98e9-73684f9f1901
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_person
+field_name: field_person
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_person_photo.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_person_photo.yml
@@ -1,0 +1,26 @@
+uuid: c5659576-90b3-4649-b594-df4591cdad01
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_person_photo
+field_name: field_person_photo
+entity_type: paragraph
+type: image
+settings:
+  default_image:
+    uuid: ''
+  uri_scheme: public
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_photo_caption.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_photo_caption.yml
@@ -1,0 +1,19 @@
+uuid: e1aa6414-612e-46a6-9406-640b45ad401d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_photo_caption
+field_name: field_photo_caption
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_photo_credit.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_photo_credit.yml
@@ -1,0 +1,21 @@
+uuid: ace7bb8f-2dbd-4927-8e74-ed852c53d54b
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_photo_credit
+field_name: field_photo_credit
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_place.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_place.yml
@@ -1,0 +1,20 @@
+uuid: b41ad354-b5fe-4569-b292-31c49777c4f6
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_place
+field_name: field_place
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_poll.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_poll.yml
@@ -1,0 +1,20 @@
+uuid: b4dfc01b-f7e3-4fbb-ad9b-2ae1ecad7063
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_poll
+field_name: field_poll
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_program_initiative.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_program_initiative.yml
@@ -1,0 +1,20 @@
+uuid: fc58b667-0138-49e3-b73c-d43f5086fd2b
+langcode: und
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_program_initiative
+field_name: field_program_initiative
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_question.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_question.yml
@@ -1,0 +1,21 @@
+uuid: 21df1432-a1c1-43a8-97ee-c7eff56ffefe
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_question
+field_name: field_question
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_right_column.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_right_column.yml
@@ -1,0 +1,19 @@
+uuid: b76c2f81-b56b-44fc-8e37-3b6b8db30960
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_right_column
+field_name: field_right_column
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_short_description.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_short_description.yml
@@ -1,0 +1,21 @@
+uuid: 64a351dc-299b-447b-b26b-2e7c12370bf3
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_short_description
+field_name: field_short_description
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_single_neighborhood.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_single_neighborhood.yml
@@ -1,0 +1,20 @@
+uuid: 89e319e1-267f-468c-af8b-49a201d89291
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_single_neighborhood
+field_name: field_single_neighborhood
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_sticky.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_sticky.yml
@@ -1,0 +1,18 @@
+uuid: 5401e10f-b16b-4191-9196-a3be4aab1c2e
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_sticky
+field_name: field_sticky
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_subheader.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_subheader.yml
@@ -1,0 +1,21 @@
+uuid: 5af006a8-e984-4e50-a22a-88df3d64f8f2
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_subheader
+field_name: field_subheader
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_thumbnail.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_thumbnail.yml
@@ -1,0 +1,26 @@
+uuid: 97d58d3b-cf86-4a03-abfd-1348a15d786b
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_thumbnail
+field_name: field_thumbnail
+entity_type: paragraph
+type: image
+settings:
+  default_image:
+    uuid: ''
+  uri_scheme: public
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_topics.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_topics.yml
@@ -1,0 +1,20 @@
+uuid: 2c73b110-f3c9-4996-b405-92659088066b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_topics
+field_name: field_topics
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_transactions.yml
+++ b/docroot/modules/custom/bos_components/config/install/field.storage.paragraph.field_transactions.yml
@@ -1,0 +1,20 @@
+uuid: 12c261a0-6757-46df-883d-def407581b1c
+langcode: und
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_transactions
+field_name: field_transactions
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_file_image_alt_text.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_file_image_alt_text.yml
@@ -1,0 +1,21 @@
+uuid: 99ac50ef-7785-41ca-b0fb-c91aad286eeb
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.field_file_image_alt_text
+field_name: field_file_image_alt_text
+entity_type: file
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_file_image_title_text.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_file_image_title_text.yml
@@ -1,0 +1,21 @@
+uuid: fa1b9d16-c5a4-4f88-9172-084c6ea18f08
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.field_file_image_title_text
+field_name: field_file_image_title_text
+entity_type: file
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_icon_category.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_icon_category.yml
@@ -1,0 +1,20 @@
+uuid: 106ad3d1-dda7-41fc-8eeb-e8223e67e165
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - taxonomy
+id: file.field_icon_category
+field_name: field_icon_category
+entity_type: file
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_image_caption.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_image_caption.yml
@@ -1,0 +1,21 @@
+uuid: 9fb26ca5-f29f-42e6-9565-031047c38cbd
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.field_image_caption
+field_name: field_image_caption
+entity_type: file
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_type_of_content.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_type_of_content.yml
@@ -1,0 +1,20 @@
+uuid: 0db7c80a-e436-454f-ac34-485b13b336f5
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - taxonomy
+id: file.field_type_of_content
+field_name: field_type_of_content
+entity_type: file
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_updated_date.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.file.field_updated_date.yml
@@ -1,0 +1,20 @@
+uuid: 8dd3bdc6-7eeb-49fd-a6f8-a777e981d46a
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - file
+id: file.field_updated_date
+field_name: field_updated_date
+entity_type: file
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.body.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.body.yml
@@ -1,0 +1,21 @@
+uuid: 127dd4cc-44ea-48b9-9078-9365d71b0a08
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+_core:
+  default_config_hash: EBUo7qOWqaiZaQ_RC9sLY5IoDKphS34v77VIHSACmVY
+id: node.body
+field_name: body
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_additional_information.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_additional_information.yml
@@ -1,0 +1,19 @@
+uuid: 6fc5e921-13f4-4e86-a665-0c29c73d468b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_additional_information
+field_name: field_additional_information
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_components.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_components.yml
@@ -1,0 +1,23 @@
+uuid: 0c082fab-ed5e-4714-b9d1-8c7a8c3c7f2c
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+_core:
+  default_config_hash: aQ2iDahizstTT2GTcN8QphFn-fVf_6ApQhKBAPJlztQ
+id: node.field_components
+field_name: field_components
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_contact.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_contact.yml
@@ -1,0 +1,22 @@
+uuid: aede178c-94ea-4d01-a477-ddef0eef56ff
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+_core:
+  default_config_hash: tgiiCupgpsWRdXvy13xwh-4yS3ZzPJ96136UhG3zAho
+id: node.field_contact
+field_name: field_contact
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_contacts.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_contacts.yml
@@ -1,0 +1,20 @@
+uuid: e763e1fc-3b8f-4019-a5d2-e9f0a98c866e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_contacts
+field_name: field_contacts
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_cost.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_cost.yml
@@ -1,0 +1,21 @@
+uuid: 6db101dc-4049-4ea6-a049-389269956e3c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_cost
+field_name: field_cost
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_department_type.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_department_type.yml
@@ -1,0 +1,27 @@
+uuid: accb2271-344a-4998-8610-ef46ba76b5f7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_department_type
+field_name: field_department_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: department
+      label: Department
+    -
+      value: cabinet
+      label: Cabinet
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_details_link.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_details_link.yml
@@ -1,0 +1,19 @@
+uuid: 7cad703a-3425-4d0a-b680-ca71abcb8941
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_details_link
+field_name: field_details_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_document.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_document.yml
@@ -1,0 +1,23 @@
+uuid: f223989f-dc37-49c3-9d07-53ec27799729
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_document
+field_name: field_document
+entity_type: node
+type: file
+settings:
+  display_default: false
+  display_field: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_email.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_email.yml
@@ -1,0 +1,21 @@
+uuid: d406fd3d-e057-4b15-826f-962bf9f4188f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_email
+field_name: field_email
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_event_contact.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_event_contact.yml
@@ -1,0 +1,21 @@
+uuid: f848ff74-5441-47d3-b78c-a87bd5aafbd0
+langcode: und
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_contact
+field_name: field_event_contact
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_sticky.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_sticky.yml
@@ -1,0 +1,18 @@
+uuid: 8bfb6f1c-6767-4002-9fec-9f476001743e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_sticky
+field_name: field_sticky
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_title.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.node.field_title.yml
@@ -1,0 +1,21 @@
+uuid: 6d1c3ac0-6f55-423a-80ba-5a7d2b276a21
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_title
+field_name: field_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.taxonomy_term.field_department_legacy_id.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.taxonomy_term.field_department_legacy_id.yml
@@ -1,0 +1,23 @@
+uuid: 946f5b1e-1706-4dd2-b9db-09b1be796d08
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: WJ6F6FneiaNCzWj55-SocLcvWUA15VCkegs9dzYPSLY
+id: taxonomy_term.field_department_legacy_id
+field_name: field_department_legacy_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.taxonomy_term.field_department_profile.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.taxonomy_term.field_department_profile.yml
@@ -1,0 +1,22 @@
+uuid: 98d2e4d6-f9c5-4182-adff-b1ae9871b696
+langcode: und
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+_core:
+  default_config_hash: QSJf5IrD9JWl-eXiOQSisTbTpufJRA4wzOyDAlY4gWY
+id: taxonomy_term.field_department_profile
+field_name: field_department_profile
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/bos_components/config/optional/field.storage.taxonomy_term.field_icon.yml
+++ b/docroot/modules/custom/bos_components/config/optional/field.storage.taxonomy_term.field_icon.yml
@@ -1,0 +1,26 @@
+uuid: cc896a31-3eb4-416a-b5a2-2f42e2038932
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - taxonomy
+id: taxonomy_term.field_icon
+field_name: field_icon
+entity_type: taxonomy_term
+type: image
+settings:
+  default_image:
+    uuid: ''
+  uri_scheme: public
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
This removes the need for the bos_shared D7 feature.  
We can add the shared field.storage.paragraphs configs into the bos_components config/install folder and then into the config/optional folder of any module that uses them.  And of course allow them to fall down into ./config/default by cex.