### PR TITLE
Update lando xdebug config to connect on drush commands

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -57,8 +57,6 @@ services:
       # Change the permissions on the log file so that non-root user can add to log.
       - chmod 777 ${LANDO_MOUNT}/setup/lando.log >> ${LANDO_MOUNT}/setup/lando.log
       # [Optional]  Do not need the next 2 statements on stage or production servers.
-      #             Here because needs root permissions to copy file to /usr/local/etc/conf.d/.
-      - cp ${LANDO_MOUNT}/scripts/phing/files/xdebug.ini /usr/local/etc/php/conf.d/boston.xdebug.ini  >> ${LANDO_MOUNT}/setup/lando.log
       # Install a custom apache config file for on-demand containers -> limits the apache children to preserve memory.
       #     (Config loaded and enabled by Phing in setup:docker:drupal-terraform)
       - cp ${LANDO_MOUNT}/scripts/phing/files/limit-apache-children.conf /etc/apache2/conf-available/ >> ${LANDO_MOUNT}/setup/lando.log
@@ -121,7 +119,6 @@ tooling:
     description: "Run drush commands in app container: lando drush <command>"
     cmd:
     - /app/vendor/bin/drush
-    - --root=/app/web
 
   drupal:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -94,6 +94,12 @@ services:
           LANDO_INFO: LANDO_INFO
           PHP_IDE_CONFIG: 'serverName=lando'
           XDEBUG_CONFIG: 'idekey=PHPSTORM'
+          XDEBUG.REMOTE_AUTOSTART: 'On'
+          XDEBUG.REMOTE_ENABLE: 'On'
+          XDEBUG.REMOTE_PORT: '9000'
+          XDEBUG.VAR_DISPLAY_MAX_DEPTH: '-1'
+          XDEBUG.VAR_DISPLAY_MAX_CHILDREN: '-1'
+          XDEBUG.VAR_DISPLAY_MAX_DATA: '-1'
 
   # set up a Varnish edge
 #  edge:
@@ -114,7 +120,8 @@ tooling:
     service: appserver
     description: "Run drush commands in app container: lando drush <command>"
     cmd:
-    - drush
+    - /app/vendor/bin/drush
+    - --root=/app/web
 
   drupal:
     service: appserver

--- a/scripts/phing/files/xdebug.ini
+++ b/scripts/phing/files/xdebug.ini
@@ -1,4 +1,0 @@
-;xdebug php settings for boston.gov.
-
-xdebug.idekey=PHPSTORM
-xdebug.remote_enable=1

--- a/scripts/phing/tasks/setup.xml
+++ b/scripts/phing/tasks/setup.xml
@@ -197,8 +197,8 @@
     </chmod>
 
     <!-- Create symbolic links for tooling -->
-    <symlink link="/usr/local/bin/drush" target="${project.basedir}/vendor/drush/drush/drush" overwrite="true" />
-    <symlink link="/usr/local/bin/phing" target="${project.basedir}/vendor/phing/phing/bin/phing" overwrite="true" />
+    <symlink link="/usr/local/bin/drush" target="${project.basedir}/vendor/bin/drush" overwrite="true" />
+    <symlink link="/usr/local/bin/phing" target="${project.basedir}/vendor/bin/phing" overwrite="true" />
     <chmod mode="755" verbose="false" quiet="true">
       <fileset dir="/usr/local/bin">
         <include name="drush"/>


### PR DESCRIPTION
@davidrkupton These updates allow drush + xdebug to work in VSCode. Turns out it had nothing to do with the IDEKey :man_shrugging:. 

The [lando docs](https://docs.devwithlando.io/tutorials/drupal8.html#recipe) say that I should have been able to do something like `drush: path:/app/vendor/bin/drush` , but for some reason that wasn't working for me. This does essentially the same thing.