### PR TITLE
Feature/internal link migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "drupal/config_override": "^1.0",
     "drupal/config_readonly": "^1.0",
     "drupal/config_split": "^1.3",
-    "drupal/config_update": "^1.5",
+    "drupal/config_update": "1.x-dev",
     "drupal/console": "^1.0.2",
     "drupal/content_access": "^1.0",
     "drupal/context": "^4.0",
@@ -186,6 +186,9 @@
       },
       "drupal/viewfield":{
         "https://www.drupal.org/project/viewfield/issues/2860523": "https://www.drupal.org/files/issues/2018-06-08/d7_upgrade_path-2860523-6.patch"
+      },
+      "drupal/config_update": {
+        "Drush 9 support": "https://www.drupal.org/files/issues/2018-06-11/drush9-support-2974637-24.patch"
       }
     }
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a27662f77a1435091982fdbe6ee70b6",
+    "content-hash": "cbb7f67b6394da99c7c60864ec91095c",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3320,17 +3320,11 @@
         },
         {
             "name": "drupal/config_update",
-            "version": "1.5.0",
+            "version": "dev-1.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/config_update",
-                "reference": "8.x-1.5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_update-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "2f7ae5f90b1c0ab8edf84680d2651e81fab6a126"
+                "reference": "944b5883edc39e58f974ece11c108f1364aba269"
             },
             "require": {
                 "drupal/core": "*"
@@ -3341,12 +3335,15 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1512587912",
+                    "version": "8.x-1.5+10-dev",
+                    "datestamp": "1524862980",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Drush 9 support": "https://www.drupal.org/files/issues/2018-06-11/drush9-support-2974637-24.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3367,7 +3364,8 @@
             "homepage": "https://www.drupal.org/project/config_update",
             "support": {
                 "source": "http://cgit.drupalcode.org/config_update"
-            }
+            },
+            "time": "2018-08-21T15:35:28+00:00"
         },
         {
             "name": "drupal/console",
@@ -15799,6 +15797,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/better_exposed_filters": 15,
+        "drupal/config_update": 20,
         "drupal/inline_entity_form": 10,
         "drupal/paragraphs_browser": 20,
         "drupal/paragraphs_edit": 15,

--- a/docroot/modules/custom/bos_migration/config/install/migrate_plus.migration.paragraph__internal_link.yml
+++ b/docroot/modules/custom/bos_migration/config/install/migrate_plus.migration.paragraph__internal_link.yml
@@ -12,8 +12,39 @@ source:
   plugin: d7_paragraphs_item
   bundle: internal_link
 process:
-  field_internal_link: field_internal_link
-  field_title: field_title
+  field_internal_link/title:
+    -
+      plugin: get
+      source: field_title/0/value
+    -
+      plugin: default_value
+      default_value: 'Migration stub: link title'
+  field_internal_link/uri:
+    plugin: migration
+    migration:
+      - d7_node:advpoll
+      - d7_node:article
+      - d7_node:change
+      - d7_node:department_profile
+      - d7_node:emergency_alert
+      - d7_node:event
+      - d7_node:how_to
+      - d7_node:landing_page
+      - d7_node:listing_page
+      - d7_node:metrolist_affordable_housing
+      - d7_node:person_profile
+      - d7_node:place_profile
+      - d7_node:post
+      - d7_node:procurement_advertisement
+      - d7_node:program_initiative_profile
+      - d7_node:public_notice
+      - d7_node:script_page
+      - d7_node:site_alert
+      - d7_node:status_item
+      - d7_node:tabbed_content
+      - d7_node:topic_page
+      - d7_node:transaction
+    source: field_internal_link/0/target_id
 destination:
   plugin: entity:paragraph
   default_bundle: internal_link


### PR DESCRIPTION
This PR:
- Adds drush 9 support to `config_update`. I like to use `lando drush config-revert` to update migration configuration items in the DB one at a time.
- Updates the internal link migration to match the new structure of the internal link component. I have not tested this migration yet because it needs to look up `nid's` from the node migrations, which haven't been tested / finalized yet. I think this is pretty close as is, but will likely need to be tweaked a bit once we get the node migrations working.