### PR TITLE
Add drush command to create component modules

### DIFF
--- a/docroot/modules/custom/bos_core/src/componentizer_templates/componentizer_template.info.yml
+++ b/docroot/modules/custom/bos_core/src/componentizer_templates/componentizer_template.info.yml
@@ -1,0 +1,9 @@
+name: componentizer_template
+type: module
+description: Provides theming and configuration for componentizer_template.
+package: City of Boston (components)
+core: 8.x
+version: 8.x.1.0
+dependencies:
+  - bos_components
+  - paragraphs

--- a/docroot/modules/custom/bos_core/src/componentizer_templates/componentizer_template.install
+++ b/docroot/modules/custom/bos_core/src/componentizer_templates/componentizer_template.install
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * The install file for componentizer_template module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function componentizer_template_uninstall() {
+  if (function_exists("_bos_core_uninstall_boston")) {
+    _bos_core_uninstall_boston(basename(__FILE__, ".install"));
+  }
+}
+
+/**
+ * Implements hook_install().
+ */
+function componentizer_template_install() {
+  // Copy icons into expected location.
+  _bos_core_install_icons(basename(__FILE__, ".install"));
+}

--- a/docroot/modules/custom/bos_core/src/componentizer_templates/componentizer_template.module
+++ b/docroot/modules/custom/bos_core/src/componentizer_templates/componentizer_template.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * The Base module file for componentizer_template module.
+ */


### PR DESCRIPTION
Adds a drush command to automate the initial creation of a component module. You can use it like this:

`lando drush componetize bos_photo --components=photo`

This will create a module called `bos_photo` as a submodule of `bos_components` and copy over the relevant configuration items. If you want multiple components to be housed in a single module, pass a comma separated list of machine names into `--components`

This command is far from perfect, and it's output should be reviewed by a human before committing, but it should save some of the repetitive manual work we're doing to create these component modules.