### PR TITLE
Attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
   - if [ ! -e  /usr/local/bin/drupal ]; then sudo ln -s ${LANDO_MOUNT}/vendor/drupal/console/bin/drupal /usr/local/bin/ ; fi
   # Make an account for drupal in MySQL (better than using root a/c).
   - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'drupal'@'localhost' IDENTIFIED BY 'drupal';"
+  - $TRAVIS_BUILD_DIR/vendor/bin/phing -f build.xml validate:all
   - travis_wait 25 $TRAVIS_BUILD_DIR/vendor/bin/phing -f $TRAVIS_BUILD_DIR/build.xml -Dgit.private_repo.user="https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/"  setup:docker:drupal-travis
   # Build the drupal site using Phing.
   - export phing="$TRAVIS_BUILD_DIR/vendor/bin/phing -f $TRAVIS_BUILD_DIR/build.xml"

--- a/docroot/themes/custom/bos_theme/bos_theme.theme
+++ b/docroot/themes/custom/bos_theme/bos_theme.theme
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\Xss;
 use Drupal\core\Template\Attribute;
+use Drupal\Core\Template\AttributeArray;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
@@ -144,6 +145,9 @@ function bos_theme_process_maintenance_page(array &$variables, $hook) {
  *   The variables to be passed to the twig template.
  */
 function bos_theme_preprocess(array &$variables, $hook) {
+  // Ensure attributes in an Attributes object.
+  _bos_theme_fix_attributes($variables);
+
   if (in_array($hook, ['html', 'page', 'node'])) {
     $variables['bos_theme'] = [
       'boston_breadcrumb' => theme_get_setting('boston_breadcrumb'),
@@ -403,12 +407,7 @@ function bos_theme_preprocess_page(array &$variables, $hook) {
     if (!isset($variables["attributes"])) {
       $variables["attributes"] = new Attribute();
     }
-    if (is_array($variables["attributes"])) {
-      $variables["attributes"]['class'][] = "page";
-    }
-    else {
-      $variables["attributes"]->addClass("page");
-    }
+    $variables["attributes"]->addClass("page");
 
     if ($variables['node']->getType() !== 'tabbed_content' && $variables['node']->getType() !== 'how_to' && !$variables['header_image']) {
       $variables["attributes"]->addClass("page--wa");
@@ -616,8 +615,12 @@ function bos_theme_preprocess_node(array &$variables, $hook) {
       ]);
     }
 
-    $variables['attributes']['id'] = 'node-' . $variables['nid'];
+    if (empty($variables["attributes"])) {
+      $variables["attributes"] = new Attribute();
+    }
+
     // Add in the necessary classes.
+    $variables['attributes']->addClass('node-' . $variables['nid']);
     $variables['attributes']['class'][] = 'node';
     $variables['attributes']['class'][] = 'node-' . _make_class($variables['node_type']);
     if ($variables['unpublished']) {
@@ -671,21 +674,27 @@ function bos_theme_preprocess_node(array &$variables, $hook) {
  */
 function bos_theme_preprocess_field(array &$variables, $hook) {
   // Emulate D7 paragraphs_items class-names.
+  if (!isset( $variables['attributes'])) {
+    $variables['attributes'] = new Attribute();
+  }
+  if (!isset( $variables['attributes']['class'])) {
+//    $variables['attributes']['class'] = new AttributeArray('class',[]);
+  }
   if ($variables['field_type'] == "entity_reference_revisions" && isset($variables['items'][0]['content']['#paragraph'])) {
-    $variables['attributes']['class'][] = "paragraphs-items";
-    $variables['attributes']['class'][] = "paragraphs-items-" . _make_class($variables['field_name']);
-    $variables['attributes']['class'][] = "paragraphs-items-" . _make_class($variables['items'][0]['content']['#view_mode']);
-    $variables['attributes']['class'][] = "paragraphs-items-" . _make_class($variables['field_name']) . "-" . _make_class($variables['items'][0]['content']['#view_mode']);
+    $variables['attributes']->addClass("paragraphs-items");
+    $variables['attributes']->addClass("paragraphs-items-" . _make_class($variables['field_name']));
+    $variables['attributes']->addClass("paragraphs-items-" . _make_class($variables['items'][0]['content']['#view_mode']));
+    $variables['attributes']->addClass("paragraphs-items-" . _make_class($variables['field_name']) . "-" . _make_class($variables['items'][0]['content']['#view_mode']));
   }
   else {
-    $variables['attributes']['class'][] = "field";
-    $variables['attributes']['class'][] = "field-name-" . _make_class($variables['field_name']);
+    $variables['attributes']->addClass("field");
+    $variables['attributes']->addClass("field-name-" . _make_class($variables['field_name']));
     if ($variables['field_type'] == "string") {
-      $variables['attributes']['class'][] = "field-type-text";
+      $variables['attributes']->addClass("field-type-text");
     }
-    $variables['attributes']['class'][] = "field-type-" . _make_class($variables['field_type']);
+    $variables['attributes']->addClass("field-type-" . _make_class($variables['field_type']));
     if (isset($variables["label_display"]) && !$variables["label_display"]) {
-      $variables['attributes']['class'][] = "field-label-hidden";
+      $variables['attributes']->addClass("field-label-hidden");
     }
   }
 
@@ -719,8 +728,8 @@ function bos_theme_preprocess_paragraph(&$variables) {
   $mode = _bos_theme_library();
   $variables['#attached']['library'][] = "bos_theme/fleet-components." . $mode;
   if (!empty($variables['paragraph'])) {
-    $variables['attributes']['class'][] = 'entity entity-paragraphs-item component-section';
-    $variables['attributes']['class'][] = 'paragraphs-item-' . str_replace('_', '-', $variables['paragraph']->bundle());
+    $variables['attributes']->addClass('entity entity-paragraphs-item component-section');
+    $variables['attributes']->addClass('paragraphs-item-' . str_replace('_', '-', $variables['paragraph']->bundle()));
   }
 }
 
@@ -868,4 +877,25 @@ function _make_class(string $class) {
  */
 function _make_nav_anchor(string $title) {
   return str_replace([" ", ":", "_", "\,"], "-", strtolower($title));
+}
+
+/**
+ * Ensure attributes element of variables array is an Attribute object.
+ *
+ * This snippet fixes the situation where a module has defined an attributes
+ * element as an array and not a Drupal\core\Template\Attribute object.
+ *
+ * @param $variables
+ *   The current variables array as generated pre-rendering.
+ */
+function _bos_theme_fix_attributes(&$variables) {
+  if (!empty($variables['attributes']) && is_array($variables['attributes'])) {
+    $attribute = new Attribute();
+    foreach ($variables["attributes"] as $key => $element) {
+      $attribute -> setAttribute($key, $element);
+    }
+    if (!empty($attribute)) {
+      $variables['attributes'] = $attribute;
+    }
+  }
 }

--- a/docroot/themes/custom/bos_theme/bos_theme.theme
+++ b/docroot/themes/custom/bos_theme/bos_theme.theme
@@ -195,22 +195,30 @@ function bos_theme_preprocess_html(array &$variables, $hook) {
   $mode = _bos_theme_library();
   $variables['#attached']['library'][] = "bos_theme/global-styling." . $mode;
 
-  $variables['attributes']['class'] = ["html"];
-  $variables['attributes']['class'][] = (\Drupal::service('path.matcher')->isFrontPage() ? "front" : "not-front");
-  $variables['attributes']['class'][] = ($variables['logged_in'] ? "logged-in" : "not-logged-in");
+  if (empty($variables["attributes"])) {
+    $variables["attributes"] = new Attribute();
+  }
+
+  $variables['attributes']->addClass("html");
+  $newClass = (\Drupal::service('path.matcher')->isFrontPage() ? "front" : "not-front");
+  $variables['attributes']->addClass($newClass);
+  $newClass = ($variables['logged_in'] ? "logged-in" : "not-logged-in");
+  $variables['attributes']->addClass($newClass);
   if ($node = drupal::request()->get('node')) {
     $nid = $node->id();
-    $variables['attributes']['class'][] = "page-node-" . (isset($nid) ? $nid : "");
+    $newClass = "page-node-" . (isset($nid) ? $nid : "");
+    $variables['attributes']->addClass($newClass);
+
   }
 
   // Detect 400-status pages.
   switch ($variables['status_code']) {
     case 403:
-      $variables['attributes']['class'][] = "page-error page-403-error body-sidebars-none section-403-forbidden";
+      $variables['attributes']->addClass("page-error page-403-error body-sidebars-none section-403-forbidden");
       break;
 
     case 404:
-      $variables['attributes']['class'][] = "page-error page-404-error body-sidebars-none section-404-not-found";
+      $variables['attributes']->addClass("page-error page-404-error body-sidebars-none section-404-not-found");
       if (!$variables["page"]["#title"] instanceof Markup) {
         $string = new TranslatableMarkup("<h1>@title</h1>", ["@title" => $variables["page"]["#title"]->getUntranslatedString()]);
         $variables["page"]["#title"] = $string;
@@ -269,8 +277,8 @@ function bos_theme_preprocess_html(array &$variables, $hook) {
 
   // Add in D7 style body classes:
   if (isset($variables['node_type'])) {
-    $variables["attributes"]['class'][] = "page-node";
-    $variables["attributes"]['class'][] = "node-type-" . _make_class($variables['node_type']);
+    $variables["attributes"]->addClass("page-node");
+    $variables["attributes"]->addClass("node-type-" . _make_class($variables['node_type']));
   }
 
 }
@@ -288,6 +296,10 @@ function bos_theme_preprocess_page(array &$variables, $hook) {
   // view-controlled html and not a fully drupal-themed page.
   if (isset($_GET['response_type']) && $_GET['response_type'] == 'embed') {
     $variables['theme_hook_suggestions'][] = 'page__embed';
+  }
+
+  if (empty($variables["attributes"])) {
+    $variables["attributes"] = new Attribute();
   }
 
   // TODO: Review if needed in D8.
@@ -334,7 +346,7 @@ function bos_theme_preprocess_page(array &$variables, $hook) {
           ->getEditable("bos_theme.settings")
           ->get("404-page");
         if (isset($variables['node'])) {
-          $variables['attributes']['data-quickedit-entity-id'] = "node/" . $variables['node']->id();
+          $variables['attributes']->setAttribute('data-quickedit-entity-id', "node/" . $variables['node']->id());
         }
         break;
 
@@ -343,7 +355,7 @@ function bos_theme_preprocess_page(array &$variables, $hook) {
           ->getEditable("bos_theme.settings")
           ->get("403-page");
         if (isset($variables['node'])) {
-          $variables['attributes']['data-quickedit-entity-id'] = "node/" . $variables['node']->id();
+          $variables['attributes']->setAttribute('data-quickedit-entity-id', "node/" . $variables['node']->id());
         }
         break;
     }
@@ -387,9 +399,6 @@ function bos_theme_preprocess_page(array &$variables, $hook) {
   $variables['#attached']['html_head'] = $metaTags;
 
   // D8 OK: Create necessary page classes.
-  if (empty($variables["attributes"])) {
-    $variables["attributes"] = new Attribute();
-  }
   if (isset($variables['node']) && is_object($variables['node'])) {
     if (!isset($variables["attributes"])) {
       $variables["attributes"] = new Attribute();

--- a/docroot/themes/custom/bos_theme/bos_theme.theme
+++ b/docroot/themes/custom/bos_theme/bos_theme.theme
@@ -13,7 +13,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\Xss;
 use Drupal\core\Template\Attribute;
-use Drupal\Core\Template\AttributeArray;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;

--- a/docroot/themes/custom/bos_theme/bos_theme.theme
+++ b/docroot/themes/custom/bos_theme/bos_theme.theme
@@ -673,11 +673,8 @@ function bos_theme_preprocess_node(array &$variables, $hook) {
  */
 function bos_theme_preprocess_field(array &$variables, $hook) {
   // Emulate D7 paragraphs_items class-names.
-  if (!isset( $variables['attributes'])) {
+  if (!isset($variables['attributes'])) {
     $variables['attributes'] = new Attribute();
-  }
-  if (!isset( $variables['attributes']['class'])) {
-//    $variables['attributes']['class'] = new AttributeArray('class',[]);
   }
   if ($variables['field_type'] == "entity_reference_revisions" && isset($variables['items'][0]['content']['#paragraph'])) {
     $variables['attributes']->addClass("paragraphs-items");
@@ -884,14 +881,14 @@ function _make_nav_anchor(string $title) {
  * This snippet fixes the situation where a module has defined an attributes
  * element as an array and not a Drupal\core\Template\Attribute object.
  *
- * @param $variables
+ * @param array $variables
  *   The current variables array as generated pre-rendering.
  */
-function _bos_theme_fix_attributes(&$variables) {
+function _bos_theme_fix_attributes(array &$variables) {
   if (!empty($variables['attributes']) && is_array($variables['attributes'])) {
     $attribute = new Attribute();
     foreach ($variables["attributes"] as $key => $element) {
-      $attribute -> setAttribute($key, $element);
+      $attribute->setAttribute($key, $element);
     }
     if (!empty($attribute)) {
       $variables['attributes'] = $attribute;


### PR DESCRIPTION
This "fixes" the situation where the attributes element of the $variables array is an array and not a Drupal\core\Template\Attribute object.
Drupal generally handles both situations provided there is consistency, but the attributes array is more correct (see "What behavior were you expecting?" on this link https://www.drupal.org/project/drupal/issues/3015783.)
When created as an Attribute object its allows adding elements (e.g. classes) in both styles:
`$variables["attributes"]["class"][] = "my-class";` (D7 syntax), and
`$variables["attributes"]->addClass("my-class");` (D8 OOPHP approach)
The problem is that when the attributes element is created as an array, any later attempted use (e.g. an element insertion) as if it were an object throws a PHP Error to the logs, and the insertion is not done. 