### PR TITLE
In page menu

### DIFF
--- a/docroot/modules/custom/bos_components/templates/field--component--field-component-title.html.twig
+++ b/docroot/modules/custom/bos_components/templates/field--component--field-component-title.html.twig
@@ -45,9 +45,6 @@
 {% set class = "sh-title" %}
 
 {% for item in items %}
-    {% if short_title %}
-        <a name="{{ short_title_link }}" data-text="{{ short_title }}" class="subnav-anchor"></a>
-    {% endif %}
     <h2{{ item.attributes.addClass(class) }} {{ attributes }}>
         {{ item.content }}
     </h2>

--- a/docroot/themes/custom/bos_theme/bos_theme.theme
+++ b/docroot/themes/custom/bos_theme/bos_theme.theme
@@ -281,7 +281,7 @@ function bos_theme_preprocess_html(array &$variables, $hook) {
   // Add in D7 style body classes:
   if (isset($variables['node_type'])) {
     $variables["attributes"]->addClass("page-node");
-    $variables["attributes"]->addClass("node-type-" . _make_class($variables['node_type']));
+    $variables["attributes"]->addClass(Html::cleanCssIdentifier("node-type-" . $variables['node_type']));
   }
 
 }
@@ -621,7 +621,7 @@ function bos_theme_preprocess_node(array &$variables, $hook) {
     // Add in the necessary classes.
     $variables['attributes']->addClass('node-' . $variables['nid']);
     $variables['attributes']['class'][] = 'node';
-    $variables['attributes']['class'][] = 'node-' . _make_class($variables['node_type']);
+    $variables['attributes']['class'][] = Html::cleanCssIdentifier('node-' . $variables['node_type']);
     if ($variables['unpublished']) {
       $variables['attributes']['class'][] = 'node-unpublished';
     }
@@ -641,7 +641,7 @@ function bos_theme_preprocess_node(array &$variables, $hook) {
           $variables['#attached']['library'][] = "bos_theme/page.component_navigation";
           // Build the in-page navigation menu and links.
           $title = $component['#paragraph']->field_short_title->value;
-          $url = Url::fromUserInput("#" . _make_nav_anchor($title), ["attributes" => ["class" => ["scroll-link-js"]]]);
+          $url = Url::fromUserInput("#" . Html::cleanCssIdentifier(strtolower($title)), ["attributes" => ["class" => ["scroll-link-js"]]]);
           $anchor = \Drupal::service('link_generator')->generate($title, $url);
           $variables['navOutput']["#items"][] = $anchor;
         }
@@ -678,17 +678,17 @@ function bos_theme_preprocess_field(array &$variables, $hook) {
   }
   if ($variables['field_type'] == "entity_reference_revisions" && isset($variables['items'][0]['content']['#paragraph'])) {
     $variables['attributes']->addClass("paragraphs-items");
-    $variables['attributes']->addClass("paragraphs-items-" . _make_class($variables['field_name']));
-    $variables['attributes']->addClass("paragraphs-items-" . _make_class($variables['items'][0]['content']['#view_mode']));
-    $variables['attributes']->addClass("paragraphs-items-" . _make_class($variables['field_name']) . "-" . _make_class($variables['items'][0]['content']['#view_mode']));
+    $variables['attributes']->addClass(Html::cleanCssIdentifier("paragraphs-items-" . $variables['field_name']));
+    $variables['attributes']->addClass(Html::cleanCssIdentifier("paragraphs-items-" . $variables['items'][0]['content']['#view_mode']));
+    $variables['attributes']->addClass(Html::cleanCssIdentifier("paragraphs-items-" . $variables['field_name'] . "-" . $variables['items'][0]['content']['#view_mode']));
   }
   else {
     $variables['attributes']->addClass("field");
-    $variables['attributes']->addClass("field-name-" . _make_class($variables['field_name']));
+    $variables['attributes']->addClass(Html::cleanCssIdentifier("field-name-" . $variables['field_name']));
     if ($variables['field_type'] == "string") {
       $variables['attributes']->addClass("field-type-text");
     }
-    $variables['attributes']->addClass("field-type-" . _make_class($variables['field_type']));
+    $variables['attributes']->addClass(Html::cleanCssIdentifier("field-type-" . $variables['field_type']));
     if (isset($variables["label_display"]) && !$variables["label_display"]) {
       $variables['attributes']->addClass("field-label-hidden");
     }
@@ -706,12 +706,15 @@ function bos_theme_preprocess_field(array &$variables, $hook) {
   /* @see https://boston.gitbook.io/digital-documentation/developer-guides-1/drupal/drupal-8/site-development-notes/content-type-back-end/in-page-navigation-menu. */
   if ($variables["field_name"] == "field_components") {
     if (!empty($variables['items'])) {
-      foreach ($variables["items"] as $key => &$item) {
-        $item['content']['nav_title']['attributes'] = new Attribute([
-          "class" => ["subnav-anchor"],
-          "name" => _make_nav_anchor($item['content']['#paragraph']->field_short_title->value),
-          "data-text" => $item['content']['#paragraph']->field_short_title->value,
-        ]);
+      foreach ($variables["items"] as $key => &$component) {
+        // Only add if the component has a short_title set.
+        if (!empty($component['content']['#paragraph']->field_short_title->value)) {
+          $component['content']['nav_title']['attributes'] = new Attribute([
+            "class" => ["subnav-anchor"],
+            "name" => Html::cleanCssIdentifier(strtolower($component['content']['#paragraph']->field_short_title->value)),
+            "data-text" => $component['content']['#paragraph']->field_short_title->value,
+          ]);
+        }
       }
     }
   }
@@ -850,32 +853,6 @@ function _bos_theme_library() {
 }
 
 /**
- * Removes reserved chars from class string.
- *
- * @param string $class
- *   The class which is to be standardised.
- *
- * @return mixed
- *   Standardised class where "-" has been replaced with "-".
- */
-function _make_class(string $class) {
-  return str_replace("_", "-", $class);
-}
-
-/**
- * Helper to change the component title into a string safe for use as an anchor.
- *
- * @param string $title
- *   Title to convert to an anchor name.
- *
- * @return string
- *   Input string with no spaces in lowercase.
- */
-function _make_nav_anchor(string $title) {
-  return str_replace([" ", ":", "_", "\,"], "-", strtolower($title));
-}
-
-/**
  * Ensure attributes element of variables array is an Attribute object.
  *
  * This snippet fixes the situation where a module has defined an attributes
@@ -885,10 +862,12 @@ function _make_nav_anchor(string $title) {
  *   The current variables array as generated pre-rendering.
  */
 function _bos_theme_fix_attributes(array &$variables) {
-  if (!empty($variables['attributes']) && is_array($variables['attributes'])) {
+  if (isset($variables['attributes']) && is_array($variables['attributes']) && class_exists(Drupal\core\Template\Attribute::class)) {
     $attribute = new Attribute();
-    foreach ($variables["attributes"] as $key => $element) {
-      $attribute->setAttribute($key, $element);
+    if (!empty($variables['attributes'])) {
+      foreach ($variables["attributes"] as $key => $element) {
+        $attribute->setAttribute($key, $element);
+      }
     }
     if (!empty($attribute)) {
       $variables['attributes'] = $attribute;

--- a/docroot/themes/custom/bos_theme/bos_theme.theme
+++ b/docroot/themes/custom/bos_theme/bos_theme.theme
@@ -862,7 +862,7 @@ function _bos_theme_library() {
  *   The current variables array as generated pre-rendering.
  */
 function _bos_theme_fix_attributes(array &$variables) {
-  if (isset($variables['attributes']) && is_array($variables['attributes']) && class_exists(Drupal\core\Template\Attribute::class)) {
+  if (isset($variables['attributes']) && is_array($variables['attributes']) && class_exists(Attribute::class)) {
     $attribute = new Attribute();
     if (!empty($variables['attributes'])) {
       foreach ($variables["attributes"] as $key => $element) {

--- a/docroot/themes/custom/bos_theme/js/component-navigation.boston.js
+++ b/docroot/themes/custom/bos_theme/js/component-navigation.boston.js
@@ -55,52 +55,76 @@
 
   'use strict';
   if ($('.topic-nav').length) {
-    var list = $('.topic-nav ul');
 
     // Creates a menu item on any element it is called on.
     if ($(".subnav-anchor").length) {
 
-      // Creates scroll effect on anchor links.
-      $('.scroll-link-js').click(function () {
-        var navOffset = 75;
-        if (!$(this).parents("nav").hasClass("sticky")) {
-          navOffset += 115;
+      var navMenu = $('.topic-nav');
+      var fixedMenu = $("#main-menu");
+      var navTop = navMenu.first("ul").offset().top;
+
+      // Returns the current position of the lower edge of the #main-menu block.
+      var menusBottom = function() {
+        return fixedMenu.position().top + fixedMenu.height();
+      };
+
+      // Collapses and expands the components menu.
+      var stickyNav = function() {
+        var stickyNavTop = navTop - menusBottom();
+        var scrollTop = $("html, body").scrollTop();
+        if ($(document).width() >= 980 && scrollTop > stickyNavTop) {
+          if (!navMenu.hasClass('sticky')) {
+            var menu_height = navMenu.outerHeight(true);
+            navMenu
+              .addClass('sticky')
+              .next().css("margin-top", menu_height);
+            $('.intro-content').addClass('nav-fill-margin');
+          }
+          stickyNavTop = navTop - menusBottom();
+          navMenu.css("top", menusBottom());
         }
-        $('html, body').animate({
-          scrollTop: $('[name="' + $.attr(this, 'href').substr(1) + '"]').offset().top - navOffset
-        }, 1);
+        else if (scrollTop <= stickyNavTop && navMenu.hasClass('sticky')) {
+          navMenu
+            .removeClass('sticky').css("top", "initial")
+            .next().css("margin-top", 0);
+          $('.intro-content').removeClass('nav-fill-margin');
+        }
+      };
+
+      // Scroll to clicked anchor, allowing for page furniture.
+      var scrollToAnchor = function(obj) {
+        var navOffset = menusBottom() - navMenu.height();
+        var loc = ($('[name="' + $.attr(obj, 'href').substr(1) + '"]').offset().top - navOffset);
+        $("html, body").animate({scrollTop: loc}, 1000, "swing");
+      };
+
+      $('.scroll-link-js').click(function (e) {
+        e.preventDefault();
+        $('.intro-content').addClass('nav-fill-margin');
+        scrollToAnchor(this);
       });
 
       // Fade in/out topic nav when .sub-nav-button link is clicked.
       $('.sub-nav-button, .sub-nav-trigger').on('click', function () {
         $(this).toggleClass('open');
-        $('.topic-nav').fadeToggle(300);
+        navMenu.fadeToggle(300);
       });
 
       // If the menu was faded out on small screens, ensures it fades back in when resized to larger screens.
-      $(window).resize(function () {
+      $(window).resize(function() {
         if ($(window).width() > 980) {
-          $('.topic-nav').fadeIn(300);
+          navMenu.fadeIn(300);
         }
       });
 
-      var TopMargin = $('.topic-nav').css('margin-top');
-      var MarginOffest = parseInt(TopMargin, 10);
-      var stickyNavTop = $('.topic-nav').offset().top - MarginOffest;
-      var stickyNav = function () {
-        var scrollTop = $(window).scrollTop();
-        if (scrollTop > stickyNavTop) {
-          $('.topic-nav').addClass('sticky');
-          $('.intro-content').addClass('nav-fill-margin');
-        }
-        else {
-          $('.topic-nav').removeClass('sticky');
-          $('.intro-content').removeClass('nav-fill-margin');
-        }
-      };
+      var navLinks = document.querySelectorAll('.scroll-link-js');
+      var navLinksArray = Array.prototype.slice.call(navLinks);
+      var scrollItems = navLinksArray.map(function (value, index) {
+        return navLinks[index].getAttribute('href');
+      });
 
       var getScrollTop = function () {
-        if (typeof pageYOffset != 'undefined') {
+        if (typeof pageYOffset !== 'undefined') {
           return pageYOffset;
         }
         else {
@@ -110,12 +134,6 @@
           return D.scrollTop;
         }
       };
-
-      var navLinks = document.querySelectorAll('.scroll-link-js');
-      var navLinksArray = Array.prototype.slice.call(navLinks);
-      var scrollItems = navLinksArray.map(function (value, index) {
-        return navLinks[index].getAttribute('href');
-      });
 
       var removeActiveState = function () {
         var activeLinks = document.querySelectorAll('.scroll-link-js.is-active');

--- a/docroot/themes/custom/bos_theme/js/component-navigation.boston.js
+++ b/docroot/themes/custom/bos_theme/js/component-navigation.boston.js
@@ -64,12 +64,12 @@
       var navTop = navMenu.first("ul").offset().top;
 
       // Returns the current position of the lower edge of the #main-menu block.
-      var menusBottom = function() {
+      var menusBottom = function () {
         return fixedMenu.position().top + fixedMenu.height();
       };
 
       // Collapses and expands the components menu.
-      var stickyNav = function() {
+      var stickyNav = function () {
         var stickyNavTop = navTop - menusBottom();
         var scrollTop = $("html, body").scrollTop();
         if ($(document).width() >= 980 && scrollTop > stickyNavTop) {
@@ -92,7 +92,7 @@
       };
 
       // Scroll to clicked anchor, allowing for page furniture.
-      var scrollToAnchor = function(obj) {
+      var scrollToAnchor = function (obj) {
         var navOffset = menusBottom() - navMenu.height();
         var loc = ($('[name="' + $.attr(obj, 'href').substr(1) + '"]').offset().top - navOffset);
         $("html, body").animate({scrollTop: loc}, 1000, "swing");
@@ -111,7 +111,7 @@
       });
 
       // If the menu was faded out on small screens, ensures it fades back in when resized to larger screens.
-      $(window).resize(function() {
+      $(window).resize(function () {
         if ($(window).width() > 980) {
           navMenu.fadeIn(300);
         }


### PR DESCRIPTION
(Majority of `bos_theme.theme` mods are from a merge i did locally and are a duplicate of whats in the `housekeeping` PR - so there should only minor changes in bos_theme.theme in `develop` if I merge this after `houskeeping`)

But, I would like to say ...   
The js is OK and the functionality is correct across the 980px breakpoint, animations are smooth and the menu collapses much more nicely than in D7 - but the problem is that lines 58-120 use jQuery and lines 120+ use js directly on the DOM.  My gut says we should have a single approach used in a single script ... but not sure if its worth the effort.  I also recall that mixing up like this can cause memory errors if jQuery and DOM objects are exchanged, but I don't think we will have that situation here. 

.. thoughts ?