### PR TITLE
Remove svg from Imagemagick pipeline as it does not work on Acquia

### DIFF
--- a/config/default/imagemagick.settings.yml
+++ b/config/default/imagemagick.settings.yml
@@ -26,9 +26,6 @@ image_formats:
     mime_type: image/gif
     weight: 10
     enabled: false
-  SVG:
-    mime_type: image/svg+xml
-    enabled: true
   WEBP:
     mime_type: image/webp
     enabled: false


### PR DESCRIPTION
Acquia is throwing errors and is unable to convert SVG images via Imagemagick (our configured image processor). I will log an issue with support, but in the short term it's easier to tell Imagemagick not to touch svg's.