### PR TITLE
Update media migration

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_quote/templates/paragraph--quote.html.twig
+++ b/docroot/modules/custom/bos_components/modules/bos_quote/templates/paragraph--quote.html.twig
@@ -29,7 +29,6 @@
       "{{ content.field_quote }}"
     </div>
   {% endif %}
-  {{ breakpoint() }}
   <div class="quote-details">
     <div class="quote-photo">
       {% if fallback_image_url %}

--- a/docroot/modules/custom/bos_core/bos_core.module
+++ b/docroot/modules/custom/bos_core/bos_core.module
@@ -304,6 +304,15 @@ function bos_core_token_info() {
 }
 
 /**
+ * Implements hook_media_embed_alter().
+ */
+function bos_core_media_embed_alter(&$build, $entity, $context) {
+  if (!empty($context['data-style'])) {
+    $build['#attributes']['style'][] = $context['data-style'];
+  }
+}
+
+/**
  * Helper to make a page title (to pass to Google Analytics).
  *
  * @param array $view_display


### PR DESCRIPTION
D7 media embeds are a weird hybrid of a token + json. Needless to say, I forgot about them in my original migration.

This PR translates those values to the D8 `entity_embed` style.

Drupal 7 supports inline styles on entity embeds, so those will now be supported on `entity_embeds` in D8. However, this is sort of secret because there is no ui to configure them. Instead, you can add inline style to an `entity_embed` using `data-style="display: block;"`. We likely don't want content editors using inline styles anyways, so this should be ok.