### PR TITLE
End to end migration.

### DIFF
--- a/config/default/core.entity_form_display.node.event.default.yml
+++ b/config/default/core.entity_form_display.node.event.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.event.field_components
     - field.field.node.event.field_contacts
     - field.field.node.event.field_cost
+    - field.field.node.event.field_date_range
     - field.field.node.event.field_description
     - field.field.node.event.field_details_link
     - field.field.node.event.field_email
@@ -31,13 +32,13 @@ dependencies:
     - field.field.node.event.field_sidebar_components
     - field.field.node.event.field_thumbnail
     - field.field.node.event.field_updated_date
-    - image.style.thumbnail
     - node.type.event
   module:
     - address
     - advanced_text_formatter
     - content_moderation
     - datetime
+    - datetime_range
     - entity_browser
     - field_group
     - link
@@ -45,7 +46,6 @@ dependencies:
     - paragraphs
     - path
     - publication_date
-    - svg_image
     - text
 third_party_settings:
   field_group:
@@ -90,6 +90,7 @@ third_party_settings:
     group_event_information:
       children:
         - field_event_dates
+        - field_date_range
         - field_city_sponsored
         - group_event_details
         - group_event_location
@@ -109,7 +110,7 @@ third_party_settings:
       children:
         - field_cost
       parent_name: group_event_information
-      weight: 26
+      weight: 27
       format_type: details
       format_settings:
         label: 'Event  Entry Fee'
@@ -124,7 +125,7 @@ third_party_settings:
         - field_address
         - field_multiple_neighborhoods
       parent_name: group_event_information
-      weight: 24
+      weight: 25
       format_type: details
       format_settings:
         id: ''
@@ -138,7 +139,7 @@ third_party_settings:
         - field_email
         - field_phone_number
       parent_name: group_event_information
-      weight: 25
+      weight: 26
       format_type: details
       format_settings:
         id: ''
@@ -189,7 +190,6 @@ third_party_settings:
       label: 'Sidebar Components'
     group_related_content:
       children:
-        - field_related_departments
         - field_related
       parent_name: group_article
       weight: 6
@@ -222,7 +222,7 @@ third_party_settings:
         - field_details_link
         - field_links
       parent_name: group_event_information
-      weight: 23
+      weight: 24
       format_type: tab
       format_settings:
         id: ''
@@ -273,7 +273,7 @@ content:
     third_party_settings: {  }
   field_city_sponsored:
     type: boolean_checkbox
-    weight: 22
+    weight: 23
     region: content
     settings:
       display_label: true
@@ -308,12 +308,18 @@ content:
     region: content
   field_cost:
     type: string_textfield
-    weight: 24
+    weight: 32
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_date_range:
+    weight: 22
+    settings: {  }
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
   field_description:
     weight: 7
     settings:
@@ -436,7 +442,7 @@ content:
     third_party_settings: {  }
   field_published_date:
     type: datetime_default
-    weight: 31
+    weight: 32
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/default/core.entity_form_display.node.site_alert.default.yml
+++ b/config/default/core.entity_form_display.node.site_alert.default.yml
@@ -3,25 +3,28 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.media_entity_browser
+    - field.field.node.site_alert.field_date_range
     - field.field.node.site_alert.field_excluded_nodes
     - field.field.node.site_alert.field_extra_info
     - field.field.node.site_alert.field_icon
     - field.field.node.site_alert.field_link
     - field.field.node.site_alert.field_theme
     - field.field.node.site_alert.title_field
-    - image.style.thumbnail
     - node.type.site_alert
   module:
     - content_moderation
+    - datetime_range
+    - entity_browser
     - field_group
     - paragraphs
     - path
     - publication_date
-    - svg_image
 third_party_settings:
   field_group:
     group_info:
       children:
+        - field_date_range
         - field_icon
         - title_field
         - field_extra_info
@@ -73,6 +76,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_date_range:
+    weight: 26
+    settings: {  }
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
   field_excluded_nodes:
     weight: 10
     type: entity_reference_autocomplete
@@ -83,7 +92,7 @@ content:
     third_party_settings: {  }
     region: content
   field_extra_info:
-    weight: 4
+    weight: 29
     type: string_textfield
     settings:
       size: 255
@@ -93,7 +102,7 @@ content:
         show_token_tree: 0
     region: content
   field_icon:
-    weight: 2
+    weight: 27
     type: entity_browser_file
     settings:
       entity_browser: media_entity_browser
@@ -107,7 +116,7 @@ content:
     third_party_settings: {  }
     region: content
   field_link:
-    weight: 5
+    weight: 30
     type: paragraphs
     settings:
       title: 'Call to Action'
@@ -126,7 +135,7 @@ content:
     third_party_settings: {  }
     region: content
   field_theme:
-    weight: 6
+    weight: 31
     type: options_select
     settings: {  }
     third_party_settings: {  }
@@ -179,7 +188,7 @@ content:
     third_party_settings: {  }
   title_field:
     type: string_textfield
-    weight: 3
+    weight: 28
     region: content
     settings:
       size: 60

--- a/config/default/core.entity_view_display.node.event.default.yml
+++ b/config/default/core.entity_view_display.node.event.default.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.field.node.event.field_thumbnail
     - field.field.node.event.field_updated_date
     - node.type.event
+    - responsive_image.styles.wide_2000x460
   module:
     - address
     - datetime
@@ -38,6 +39,7 @@ dependencies:
     - fences
     - link
     - options
+    - responsive_image
     - svg_image
     - text
     - user
@@ -232,18 +234,21 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_intro_image:
-    type: image
+    type: responsive_image
     weight: 18
     region: content
     label: hidden
     settings:
-      svg_attributes:
-        width: ''
-        height: ''
-      svg_render_as_image: true
-      image_style: ''
+      responsive_image_style: wide_2000x460
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
   field_links:
     type: entity_reference_revisions_entity_view
     weight: 12

--- a/config/default/core.entity_view_display.node.event.default.yml
+++ b/config/default/core.entity_view_display.node.event.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.event.field_components
     - field.field.node.event.field_contacts
     - field.field.node.event.field_cost
+    - field.field.node.event.field_date_range
     - field.field.node.event.field_description
     - field.field.node.event.field_details_link
     - field.field.node.event.field_email
@@ -35,6 +36,7 @@ dependencies:
   module:
     - address
     - datetime
+    - datetime_range
     - entity_reference_revisions
     - fences
     - link
@@ -64,9 +66,16 @@ content:
         fences_label_classes: ''
   field_address:
     weight: 25
-    label: above
+    label: hidden
     settings: {  }
-    third_party_settings: {  }
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
     type: address_default
     region: content
   field_cancel_event:
@@ -109,7 +118,7 @@ content:
       link: ''
     third_party_settings: {  }
   field_contacts:
-    weight: 14
+    weight: 15
     label: hidden
     settings:
       link: true
@@ -118,7 +127,7 @@ content:
     region: content
   field_cost:
     type: string
-    weight: 9
+    weight: 10
     region: content
     label: inline
     settings:
@@ -131,6 +140,23 @@ content:
         fences_field_item_classes: 'detail-item__body detail-item__body--secondary'
         fences_label_tag: none
         fences_label_classes: ''
+  field_date_range:
+    weight: 6
+    label: inline
+    settings:
+      timezone_override: America/New_York
+      format_type: date_format_normal_date
+      separator: ''
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: daterange_default
+    region: content
   field_description:
     weight: 3
     label: hidden
@@ -159,7 +185,7 @@ content:
     third_party_settings: {  }
   field_email:
     type: string
-    weight: 6
+    weight: 7
     region: content
     label: hidden
     settings:
@@ -174,7 +200,7 @@ content:
         fences_label_classes: ''
   field_event_contact:
     type: string
-    weight: 8
+    weight: 9
     region: content
     label: hidden
     settings:
@@ -205,7 +231,7 @@ content:
         fences_label_classes: ''
   field_event_type:
     type: entity_reference_label
-    weight: 11
+    weight: 12
     region: content
     label: inline
     settings:
@@ -251,7 +277,7 @@ content:
         fences_label_classes: ''
   field_links:
     type: entity_reference_revisions_entity_view
-    weight: 12
+    weight: 13
     region: content
     label: inline
     settings:
@@ -266,7 +292,7 @@ content:
         fences_label_tag: none
         fences_label_classes: ''
   field_manual_date:
-    weight: 15
+    weight: 16
     label: hidden
     settings:
       format: default
@@ -277,7 +303,7 @@ content:
     region: content
   field_multiple_neighborhoods:
     type: entity_reference_label
-    weight: 10
+    weight: 11
     region: content
     label: inline
     settings:
@@ -292,7 +318,7 @@ content:
         fences_label_classes: ''
   field_phone_number:
     type: string
-    weight: 7
+    weight: 8
     region: content
     label: hidden
     settings:
@@ -307,7 +333,7 @@ content:
         fences_label_classes: ''
   field_published_date:
     type: datetime_default
-    weight: 13
+    weight: 14
     region: content
     label: inline
     settings:
@@ -331,7 +357,7 @@ content:
     region: content
   field_sidebar_components:
     type: entity_reference_revisions_entity_view
-    weight: 16
+    weight: 17
     region: content
     label: hidden
     settings:

--- a/config/default/core.entity_view_display.node.site_alert.default.yml
+++ b/config/default/core.entity_view_display.node.site_alert.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.site_alert.field_date_range
     - field.field.node.site_alert.field_excluded_nodes
     - field.field.node.site_alert.field_extra_info
     - field.field.node.site_alert.field_icon
@@ -11,6 +12,7 @@ dependencies:
     - field.field.node.site_alert.title_field
     - node.type.site_alert
   module:
+    - datetime_range
     - entity_reference_revisions
     - fences
     - options
@@ -22,20 +24,29 @@ bundle: site_alert
 mode: default
 content:
   content_moderation_control:
-    weight: -20
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_date_range:
+    type: daterange_plain
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      separator: '-'
+      timezone_override: ''
+    third_party_settings: {  }
   field_excluded_nodes:
     label: hidden
-    weight: 5
+    weight: 6
     type: entity_reference_entity_id
     settings: {  }
     third_party_settings: {  }
     region: content
   field_extra_info:
     type: string
-    weight: 2
+    weight: 3
     region: content
     label: hidden
     settings:
@@ -43,7 +54,7 @@ content:
     third_party_settings: {  }
   field_icon:
     label: hidden
-    weight: 0
+    weight: 1
     type: image
     settings:
       image_style: ''
@@ -63,7 +74,7 @@ content:
     region: content
   field_link:
     label: hidden
-    weight: 3
+    weight: 4
     type: entity_reference_revisions_entity_view
     settings:
       view_mode: default
@@ -79,14 +90,14 @@ content:
     region: content
   field_theme:
     label: hidden
-    weight: 4
+    weight: 5
     type: list_default
     settings: {  }
     third_party_settings: {  }
     region: content
   title_field:
     type: string
-    weight: 1
+    weight: 2
     region: content
     label: hidden
     settings:

--- a/config/default/field.field.node.event.field_date_range.yml
+++ b/config/default/field.field.node.event.field_date_range.yml
@@ -1,0 +1,21 @@
+uuid: d9c28f04-8d7a-406f-af79-3e82998411fe
+langcode: und
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_range
+    - node.type.event
+  module:
+    - datetime_range
+id: node.event.field_date_range
+field_name: field_date_range
+entity_type: node
+bundle: event
+label: 'Event Dates'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/config/default/field.field.node.event.field_intro_image.yml
+++ b/config/default/field.field.node.event.field_intro_image.yml
@@ -20,14 +20,14 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: 'event-intro-image-[current-date:date_format_file_directory_storage_date]'
+  file_directory: 'img/event/intro_images/[current-date:html_year]/[current-date:html_month_bare]'
   file_extensions: 'png gif jpg jpeg svg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
   alt_field: true
   alt_field_required: true
-  title_field: true
+  title_field: false
   title_field_required: false
   default_image:
     uuid: ''

--- a/config/default/field.field.node.site_alert.field_date_range.yml
+++ b/config/default/field.field.node.site_alert.field_date_range.yml
@@ -1,0 +1,26 @@
+uuid: 7a6593dd-f834-45da-8072-a3913c43e60b
+langcode: und
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_range
+    - node.type.site_alert
+  module:
+    - datetime_range
+id: node.site_alert.field_date_range
+field_name: field_date_range
+entity_type: node
+bundle: site_alert
+label: Active
+description: "Set a start and end date/time when this alert will display on all pages of the main website (except those excluded).<br>\r\nIf there is no start or end date, the alert will not be displayed. <br>\r\n<i><b>Note: </b> Up to 3 alerts will be displayed on any page.</i>\r\n<i><b>Note: </b> To disable an alert either delete the start and end dates, or set both to be in the past</i>"
+required: false
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+    default_end_date_type: ''
+    default_end_date: ''
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/config/default/field.field.node.site_alert.field_extra_info.yml
+++ b/config/default/field.field.node.site_alert.field_extra_info.yml
@@ -9,8 +9,8 @@ id: node.site_alert.field_extra_info
 field_name: field_extra_info
 entity_type: node
 bundle: site_alert
-label: Content
-description: 'The main text of the alert.'
+label: 'Alert Text'
+description: "The information being communicated by this alert.  This will display in the main body of the alert message.<br>\r\n<i><b>Style Guide</b> Use plain text only.</i>"
 required: true
 translatable: false
 default_value: {  }

--- a/config/default/field.field.node.site_alert.field_icon.yml
+++ b/config/default/field.field.node.site_alert.field_icon.yml
@@ -12,7 +12,7 @@ field_name: field_icon
 entity_type: node
 bundle: site_alert
 label: Icon
-description: 'This should be an icon with a circle (same ones used for status updates).'
+description: "The icon will display as the left-most element on the site alert.<br>\r\n<i><b>Style Guide:</b> This should be an icon with a circle (same style as used for status updates).</i>"
 required: false
 translatable: false
 default_value: {  }
@@ -25,8 +25,8 @@ settings:
   min_resolution: ''
   alt_field: true
   alt_field_required: true
-  title_field: true
-  title_field_required: true
+  title_field: false
+  title_field_required: false
   default_image:
     uuid: ''
     alt: ''

--- a/config/default/field.field.node.site_alert.field_link.yml
+++ b/config/default/field.field.node.site_alert.field_link.yml
@@ -15,12 +15,13 @@ field_name: field_link
 entity_type: node
 bundle: site_alert
 label: 'Call to Action'
-description: 'A link to either an external site, an internal page, or a document.'
+description: '[optional] A link to either an external site, an internal page, or a document.'
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:paragraph'
   handler_settings:
     negate: 0
     target_bundles:
@@ -29,220 +30,198 @@ settings:
       internal_link: internal_link
     target_bundles_drag_drop:
       3_column_w_image:
-        enabled: false
         weight: 2
+        enabled: false
       bos311:
-        enabled: false
         weight: 3
+        enabled: false
       cabinet:
-        enabled: false
         weight: 4
+        enabled: false
       city_score_dashboard:
-        enabled: false
         weight: 5
+        enabled: false
       custom_hours_text:
-        enabled: false
         weight: 6
+        enabled: false
       daily_hours:
-        enabled: false
         weight: 7
-      discussion_topic:
         enabled: false
+      discussion_topic:
         weight: 8
+        enabled: false
       document:
         enabled: true
         weight: 9
       drawer:
-        enabled: false
         weight: 10
+        enabled: false
       drawers:
-        enabled: false
         weight: 11
-      election_results:
         enabled: false
+      election_results:
         weight: 12
+        enabled: false
       external_link:
         enabled: true
         weight: 13
-      featured_item:
-        enabled: false
-        weight: 14
       featured_topics:
-        enabled: false
         weight: 15
-      feedback:
         enabled: false
-        weight: 16
       fyi:
-        enabled: false
         weight: 17
+        enabled: false
       gol_list_links:
-        enabled: false
         weight: 18
+        enabled: false
       grid_of_people:
-        enabled: false
         weight: 19
+        enabled: false
       grid_of_places:
-        enabled: false
         weight: 20
+        enabled: false
       grid_of_programs_initiatives:
-        enabled: false
         weight: 21
+        enabled: false
       grid_of_quotes:
-        enabled: false
         weight: 22
+        enabled: false
       grid_of_topics:
-        enabled: false
         weight: 23
+        enabled: false
       group_of_links_grid:
-        enabled: false
         weight: 24
+        enabled: false
       group_of_links_list:
-        enabled: false
         weight: 25
+        enabled: false
       group_of_links_mini_grid:
-        enabled: false
         weight: 26
+        enabled: false
       header_text:
-        enabled: false
         weight: 27
+        enabled: false
       hero_image:
-        enabled: false
         weight: 28
+        enabled: false
       how_to_contact_step:
-        enabled: false
         weight: 29
+        enabled: false
       how_to_tab:
-        enabled: false
         weight: 30
+        enabled: false
       how_to_text_step:
-        enabled: false
         weight: 31
-      iframe:
         enabled: false
+      iframe:
         weight: 32
+        enabled: false
       internal_link:
         enabled: true
         weight: 33
       list:
-        enabled: false
         weight: 34
+        enabled: false
       message_for_the_day:
-        enabled: false
         weight: 35
+        enabled: false
       news_and_announcements:
-        enabled: false
         weight: 36
+        enabled: false
       photo:
-        enabled: false
         weight: 37
+        enabled: false
       quote:
-        enabled: false
         weight: 38
-      recollect_widget:
         enabled: false
-        weight: 39
-      script_embed:
-        enabled: false
-        weight: 40
       seamless_doc:
-        enabled: false
         weight: 41
+        enabled: false
       sidebar_item:
-        enabled: false
         weight: 42
+        enabled: false
       sidebar_item_w_icon:
-        enabled: false
         weight: 43
+        enabled: false
       social_media_links:
-        enabled: false
         weight: 44
+        enabled: false
       social_networking:
-        enabled: false
         weight: 45
-      status_override:
         enabled: false
-        weight: 46
       tabbed_content_tab:
-        enabled: false
         weight: 47
+        enabled: false
       text:
-        enabled: false
         weight: 48
+        enabled: false
       text_one_column:
-        enabled: false
         weight: 49
+        enabled: false
       text_three_column:
-        enabled: false
         weight: 50
+        enabled: false
       text_two_column:
-        enabled: false
         weight: 51
+        enabled: false
       transaction_grid:
-        enabled: false
         weight: 52
+        enabled: false
       upcoming_events:
-        enabled: false
         weight: 53
-      user_action:
         enabled: false
-        weight: 54
       video:
-        enabled: false
         weight: 55
+        enabled: false
       bid:
-        enabled: false
         weight: 56
+        enabled: false
       bos_signup_emergency_alerts:
-        enabled: false
         weight: 57
+        enabled: false
       card:
-        enabled: false
         weight: 58
+        enabled: false
       columns:
-        enabled: false
         weight: 59
+        enabled: false
       commission_contact_info:
-        enabled: false
         weight: 60
-      commission_info:
         enabled: false
-        weight: 61
       commission_members:
-        enabled: false
         weight: 62
+        enabled: false
       commission_summary:
-        enabled: false
         weight: 63
+        enabled: false
       grid_links:
-        enabled: false
         weight: 64
+        enabled: false
       grid_of_cards:
-        enabled: false
         weight: 65
+        enabled: false
       lightbox_link:
-        enabled: false
         weight: 66
+        enabled: false
       map:
-        enabled: false
         weight: 67
-      map_coordinates:
         enabled: false
-        weight: 68
-      map_esri_feed:
-        enabled: false
-        weight: 69
-      map_pin:
-        enabled: false
-        weight: 70
       newsletter:
-        enabled: false
         weight: 71
-      transactions:
         enabled: false
+      transactions:
         weight: 72
+        enabled: false
+      commission_search:
+        weight: 76
+        enabled: false
+      from_library:
+        weight: 88
+        enabled: false
+      status_overrides:
+        weight: 121
+        enabled: false
       events_and_notices:
         weight: 125
         enabled: false
-  handler: 'default:paragraph'
 field_type: entity_reference_revisions

--- a/config/default/field.field.node.site_alert.field_theme.yml
+++ b/config/default/field.field.node.site_alert.field_theme.yml
@@ -12,7 +12,7 @@ field_name: field_theme
 entity_type: node
 bundle: site_alert
 label: Theme
-description: 'Site alerts can be red or blue. Pick one.'
+description: 'Site alerts can be set to use a red or blue background.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/default/field.field.node.site_alert.title_field.yml
+++ b/config/default/field.field.node.site_alert.title_field.yml
@@ -10,7 +10,7 @@ field_name: title_field
 entity_type: node
 bundle: site_alert
 label: Title
-description: 'This is the heading of the FYI.'
+description: 'This is the heading which will appear in the left on the Site Alert.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/default/views.view.site_alerts.yml
+++ b/config/default/views.view.site_alerts.yml
@@ -23,6 +23,7 @@ dependencies:
     - node.type.site_alert
     - node.type.topic_page
   module:
+    - datetime
     - image_url_formatter
     - node
     - rest
@@ -156,6 +157,92 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        field_date_range_value:
+          id: field_date_range_value
+          table: node__field_date_range
+          field: field_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+        field_date_range_end_value:
+          id: field_date_range_end_value
+          table: node__field_date_range
+          field: field_date_range_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
       sorts:
         created:
           id: created
@@ -755,10 +842,38 @@ display:
       defaults:
         title: false
         show_admin_links: false
+        sorts: false
+        pager: false
       allow:
         items_per_page: false
       block_description: 'Site Alerts'
       show_admin_links: false
+      sorts:
+        field_date_range_value:
+          id: field_date_range_value
+          table: node__field_date_range
+          field: field_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+      pager:
+        type: some
+        options:
+          items_per_page: 3
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:

--- a/docroot/modules/custom/bos_components/modules/bos_commissions/bos_commissions.libraries.yml
+++ b/docroot/modules/custom/bos_components/modules/bos_commissions/bos_commissions.libraries.yml
@@ -1,6 +1,6 @@
 bos_commissions_search:
   version: 1.0
   js:
-    https://apps.boston.gov/commissions-search/static/js/main.js: {type:external, minified:true}
+    https://apps.boston.gov/commissions-search/static/js/main.js: {type: external, minified: true}
   dependencies:
     - core/drupalSettings

--- a/docroot/modules/custom/bos_components/modules/bos_lightbox/bos_lightbox.libraries.yml
+++ b/docroot/modules/custom/bos_components/modules/bos_lightbox/bos_lightbox.libraries.yml
@@ -1,9 +1,9 @@
 lity:
   version: 2.3.1
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/lity/2.3.1/lity.min.js: {type:external, minified:true}
+    https://cdnjs.cloudflare.com/ajax/libs/lity/2.3.1/lity.min.js: {type: external, minified: true}
   dependencies:
     - core/jquery
   css:
     theme:
-      https://cdnjs.cloudflare.com/ajax/libs/lity/2.3.1/lity.min.css: {type:external, minified:true}
+      https://cdnjs.cloudflare.com/ajax/libs/lity/2.3.1/lity.min.css: {type: external, minified: true}

--- a/docroot/modules/custom/bos_components/modules/bos_map/bos_map.libraries.yml
+++ b/docroot/modules/custom/bos_components/modules/bos_map/bos_map.libraries.yml
@@ -1,6 +1,6 @@
 map:
   js:
-    https://patterns.boston.gov/web-components/fleetcomponents.js: {type:external, minified:true}
+    https://patterns.boston.gov/web-components/fleetcomponents.js: {type: external, minified: true}
   css:
     theme:
       css/styles.css: {}

--- a/docroot/modules/custom/bos_content/modules/node_event/node_event.info.yml
+++ b/docroot/modules/custom/bos_content/modules/node_event/node_event.info.yml
@@ -43,6 +43,7 @@ config_devel:
   - field.field.node.event.field_components
   - field.field.node.event.field_event_type
   - field.field.node.event.field_event_dates
+  - field.field.node.event.field_date_range
   - field.field.node.event.field_intro_image
   - field.field.node.event.field_cancel_event
   - field.field.node.event.field_details_link

--- a/docroot/modules/custom/bos_content/modules/node_event/node_event.module
+++ b/docroot/modules/custom/bos_content/modules/node_event/node_event.module
@@ -54,8 +54,7 @@ function template_preprocess_node__event(array &$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function node_event_preprocess_page(&$variables) {
-  if (isset($variables["node"]) && is_object($variables['node']) && $variables["node"]->bundle() != "event") {
+function node_event_preprocess_page(&$variables) {if (isset($variables["node"]) && is_object($variables['node']) && $variables["node"]->bundle() != "event") {
     return;
   }
   $variables["header_image"] = !empty($variables["node"]->field_intro_image);

--- a/docroot/modules/custom/bos_content/modules/node_event/node_event.module
+++ b/docroot/modules/custom/bos_content/modules/node_event/node_event.module
@@ -55,7 +55,7 @@ function template_preprocess_node__event(array &$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function node_event_preprocess_page(&$variables) {
-  if ($variables["node"]->bundle() != "event") {
+  if (isset($variables["node"]) && is_object($variables['node']) && $variables["node"]->bundle() != "event") {
     return;
   }
   $variables["header_image"] = !empty($variables["node"]->field_intro_image);
@@ -140,4 +140,16 @@ function node_event_preprocess_node__event(&$variables) {
     $variables["is_cancelled"] = ($node->field_cancelled->value == "1");
   }
 
+}
+
+function node_event_preprocess_field__field_address(&$variables) {
+  // Hide the country field in the address.
+  if ($variables["element"]["#bundle"] != "event") {
+    return;
+  }
+  if (isset($variables["items"])) {
+    foreach ($variables["items"] as $key => &$item) {
+      $item["content"]["country"]["#attributes"]["class"][] = "hidden";
+    }
+  }
 }

--- a/docroot/modules/custom/bos_content/modules/node_event/node_event.module
+++ b/docroot/modules/custom/bos_content/modules/node_event/node_event.module
@@ -54,6 +54,16 @@ function template_preprocess_node__event(array &$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
+function node_event_preprocess_page(&$variables) {
+  if ($variables["node"]->bundle() != "event") {
+    return;
+  }
+  $variables["header_image"] = !empty($variables["node"]->field_intro_image);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function node_event_preprocess_node__event(&$variables) {
   _bos_theme_fix_attributes($variables);
   $variables['attributes']->addClass('desktop-100');

--- a/docroot/modules/custom/bos_content/modules/node_event/node_event.module
+++ b/docroot/modules/custom/bos_content/modules/node_event/node_event.module
@@ -54,7 +54,8 @@ function template_preprocess_node__event(array &$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function node_event_preprocess_page(&$variables) {if (isset($variables["node"]) && is_object($variables['node']) && $variables["node"]->bundle() != "event") {
+function node_event_preprocess_page(&$variables) {
+  if (isset($variables["node"]) && is_object($variables['node']) && $variables["node"]->bundle() != "event") {
     return;
   }
   $variables["header_image"] = !empty($variables["node"]->field_intro_image);
@@ -141,6 +142,9 @@ function node_event_preprocess_node__event(&$variables) {
 
 }
 
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function node_event_preprocess_field__field_address(&$variables) {
   // Hide the country field in the address.
   if ($variables["element"]["#bundle"] != "event") {

--- a/docroot/modules/custom/bos_content/modules/node_site_alert/node_site_alert.info.yml
+++ b/docroot/modules/custom/bos_content/modules/node_site_alert/node_site_alert.info.yml
@@ -13,6 +13,7 @@ config_devel:
   - core.entity_form_display.node.site_alert.default
   - core.entity_view_display.node.site_alert.default
   - core.entity_view_display.node.site_alert.teaser
+  - field.field.node.site_alert.field_date_range
   - field.field.node.site_alert.field_excluded_nodes
   - field.field.node.site_alert.field_extra_info
   - field.field.node.site_alert.field_icon

--- a/docroot/modules/custom/bos_content/modules/node_site_alert/node_site_alert.module
+++ b/docroot/modules/custom/bos_content/modules/node_site_alert/node_site_alert.module
@@ -57,7 +57,7 @@ function node_site_alert_theme() {
  *   - attributes: HTML attributes for the containing element.
  *   TODO: This is not working ... hook does not exist.
  */
-function template_preprocess_site_alert(array &$variables) {
+function template_preprocess_node__site_alert(array &$variables) {
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
@@ -123,9 +123,14 @@ function node_site_alert_preprocess(&$variables, $hook) {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function node_site_alert_preprocess_node(&$variables) {
+function node_site_alert_preprocess_node__site_alert(&$variables) {
   if ($variables['node']->bundle() != "site_alert") {
     return;
+  }
+
+  // Only show alert if the date range is valid.
+  if (!isset($variables["node"]->field_date_range)) {
+    $variables["display"] = TRUE;
   }
 
   // Add-in a bit of css.

--- a/docroot/modules/custom/bos_migration/bos_migration.module
+++ b/docroot/modules/custom/bos_migration/bos_migration.module
@@ -5,8 +5,11 @@
  * Main file for the bos_migration module.
  */
 
+use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\MigrateSourceInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\bos_migration\MigrationConfigAlter;
-
+use Drupal\bos_migration\MigrationPrepareRow;
 /**
  * Implements hook_migration_plugins_alter().
  */
@@ -16,4 +19,16 @@ function bos_migration_migration_plugins_alter(array &$migrations) {
   $migrations = $mig->alterMigrations();
   // TODO: dumpMigration() can be removed in production.
   $mig->dumpMigration();
+}
+
+/**
+ * Implements hook_migrate_prepare_row().
+ */
+function bos_migration_migrate_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
+  $mig = new MigrationPrepareRow($row, $source, $migration);
+  switch ($migration->get("id")) {
+    case "d7_node_revision":
+      $mig->prepareNodeRevisionRow();
+      break;
+  }
 }

--- a/docroot/modules/custom/bos_migration/bos_migration.module
+++ b/docroot/modules/custom/bos_migration/bos_migration.module
@@ -10,6 +10,7 @@ use Drupal\migrate\Plugin\MigrateSourceInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\bos_migration\MigrationConfigAlter;
 use Drupal\bos_migration\MigrationPrepareRow;
+
 /**
  * Implements hook_migration_plugins_alter().
  */

--- a/docroot/modules/custom/bos_migration/src/EventSubscriber/EntityRevisionsSaveSubscriber.php
+++ b/docroot/modules/custom/bos_migration/src/EventSubscriber/EntityRevisionsSaveSubscriber.php
@@ -57,7 +57,6 @@ class EntityRevisionsSaveSubscriber implements EventSubscriberInterface {
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function migrateRowPostSave(MigratePostRowSaveEvent $event) {
     if ($event->getMigration()->get("migration_group") != "d7_node_revision"
@@ -113,9 +112,9 @@ class EntityRevisionsSaveSubscriber implements EventSubscriberInterface {
             "@node_type" => $event->getMigration()
               ->getSourceConfiguration()['node_type'],
           ];
-          $msg = \Drupal::translation()
-            ->translate("@node_type:#@id set revision @rev_id (orig:@orig_rev_id) moderation from @old_state to @state.", $params);
-          $event->logMessage($msg->render());
+//          $msg = \Drupal::translation()
+//            ->translate("@node_type:#@id set revision @rev_id (orig:@orig_rev_id) moderation from @old_state to @state.", $params);
+//          $event->logMessage($msg->render());
         }
 
         // If revision is "published" i.e status = 1 and content_mod = published
@@ -127,15 +126,15 @@ class EntityRevisionsSaveSubscriber implements EventSubscriberInterface {
           // and set its status to 1.
           MigrationPrepareRow::setNodeStatus($vid, $workbench_d7['published']);
 
-          $params = [
-            "@id" => $revision_d8->id(),
-            "@rev_id" => $vid,
-            "@node_type" => $event->getMigration()
-              ->getSourceConfiguration()['node_type'],
-          ];
-          $msg = \Drupal::translation()
-            ->translate("@node_type:#@id set revision @rev_id status to TRUE.", $params);
-          $event->logMessage($msg->render());
+//          $params = [
+//            "@id" => $revision_d8->id(),
+//            "@rev_id" => $vid,
+//            "@node_type" => $event->getMigration()
+//              ->getSourceConfiguration()['node_type'],
+//          ];
+//          $msg = \Drupal::translation()
+//            ->translate("@node_type:#@id set revision @rev_id status to TRUE.", $params);
+//          $event->logMessage($msg->render());
         }
 
         // If the last workbench state for this revision is marked "current"

--- a/docroot/modules/custom/bos_migration/src/EventSubscriber/EntityRevisionsSaveSubscriber.php
+++ b/docroot/modules/custom/bos_migration/src/EventSubscriber/EntityRevisionsSaveSubscriber.php
@@ -112,9 +112,9 @@ class EntityRevisionsSaveSubscriber implements EventSubscriberInterface {
             "@node_type" => $event->getMigration()
               ->getSourceConfiguration()['node_type'],
           ];
-//          $msg = \Drupal::translation()
-//            ->translate("@node_type:#@id set revision @rev_id (orig:@orig_rev_id) moderation from @old_state to @state.", $params);
-//          $event->logMessage($msg->render());
+          /*$msg = \Drupal::translation()
+          ->translate("@node_type:#@id set revision @rev_id (orig:@orig_rev_id) moderation from @old_state to @state.", $params);
+          $event->logMessage($msg->render());*/
         }
 
         // If revision is "published" i.e status = 1 and content_mod = published
@@ -126,15 +126,15 @@ class EntityRevisionsSaveSubscriber implements EventSubscriberInterface {
           // and set its status to 1.
           MigrationPrepareRow::setNodeStatus($vid, $workbench_d7['published']);
 
-//          $params = [
-//            "@id" => $revision_d8->id(),
-//            "@rev_id" => $vid,
-//            "@node_type" => $event->getMigration()
-//              ->getSourceConfiguration()['node_type'],
-//          ];
-//          $msg = \Drupal::translation()
-//            ->translate("@node_type:#@id set revision @rev_id status to TRUE.", $params);
-//          $event->logMessage($msg->render());
+          /*$params = [
+          "@id" => $revision_d8->id(),
+          "@rev_id" => $vid,
+          "@node_type" => $event->getMigration()
+          ->getSourceConfiguration()['node_type'],
+          ];
+          $msg = \Drupal::translation()
+          ->translate("@node_type:#@id set revision @rev_id status to TRUE.", $params);
+          $event->logMessage($msg->render());*/
         }
 
         // If the last workbench state for this revision is marked "current"

--- a/docroot/modules/custom/bos_migration/src/MigrationConfigAlter.php
+++ b/docroot/modules/custom/bos_migration/src/MigrationConfigAlter.php
@@ -353,6 +353,23 @@ class MigrationConfigAlter {
         ],
       ],
     ],
+    // Manually add the custom title field.
+    "d7_node:site_alert" => [
+      "process" => [
+        "title_field" => "title_field",
+      ],
+    ],
+    "d7_node_revision:site_alert" => [
+      "process" => [
+        "title_field" => "title_field",
+      ],
+    ],
+    "d7_node_entity_translation:site_alert" => [
+      "process" => [
+        "title_field" => "title_field",
+      ],
+    ],
+
     // Manually adds dependency on department profile.
     "d7_taxonomy_term:contact" => [
       "migration_dependencies" => [

--- a/docroot/modules/custom/bos_migration/src/MigrationPrepareRow.php
+++ b/docroot/modules/custom/bos_migration/src/MigrationPrepareRow.php
@@ -242,7 +242,7 @@ class MigrationPrepareRow {
    * @param string $state
    *   The content_moderation status (published/draft/need_review)
    */
-  public static function setModerationState($vid, $state) {
+  public static function setModerationState(int $vid, string $state) {
     \Drupal::database()->update("content_moderation_state_field_data")
       ->fields([
         "moderation_state" => $state,
@@ -265,10 +265,10 @@ class MigrationPrepareRow {
    *   Node to be set.
    * @param int $vid
    *   Node revision to be set.
-   * @param bool $isPublished
+   * @param int $isPublished
    *   Is this revision's status = 1 (drupal-published)
    */
-  public static function setCurrentRevision(int $nid, int $vid, bool $isPublished) {
+  public static function setCurrentRevision(int $nid, int $vid, int $isPublished = 0) {
     // Set the node vid to be the current revision.
     // Table: node.
     \Drupal::database()->update("node")
@@ -304,14 +304,12 @@ class MigrationPrepareRow {
     // Only set the revision default to be true if this revision is pub.
     // Note: $isPublished=NULL means no revision is currently published.
     // Table: node_revision.
-    if (isset($isPublished)) {
-      \Drupal::database()->update("node_revision")
-        ->fields([
-          "revision_default" => $isPublished,
-        ])
-        ->condition('vid', $vid)
-        ->execute();
-    }
+    \Drupal::database()->update("node_revision")
+      ->fields([
+        "revision_default" => $isPublished,
+      ])
+      ->condition('vid', $vid)
+      ->execute();
   }
 
   /**
@@ -321,10 +319,10 @@ class MigrationPrepareRow {
    *   Node to be set.
    * @param int $vid
    *   Node revision to be set.
-   * @param bool $isPublished
+   * @param int $isPublished
    *   Is this revision's status = 1 (drupal-published)
    */
-  public static function setCurrentModerationRevision(int $nid, int $vid, bool $isPublished) {
+  public static function setCurrentModerationRevision(int $nid, int $vid, int $isPublished = 0) {
     // Get the id and rev_id for the moderation state.
     $query = \Drupal::database()->select("content_moderation_state_field_revision", "rev")
       ->fields("rev", ["id", "revision_id"]);

--- a/docroot/modules/custom/bos_migration/src/MigrationPrepareRow.php
+++ b/docroot/modules/custom/bos_migration/src/MigrationPrepareRow.php
@@ -302,13 +302,16 @@ class MigrationPrepareRow {
     \Drupal::database()->query($qstring)->execute();
 
     // Only set the revision default to be true if this revision is pub.
+    // Note: $isPublished=NULL means no revision is currently published.
     // Table: node_revision.
-    \Drupal::database()->update("node_revision")
-      ->fields([
-        "revision_default" => $isPublished,
-      ])
-      ->condition('vid', $vid)
-      ->execute();
+    if (isset($isPublished)) {
+      \Drupal::database()->update("node_revision")
+        ->fields([
+          "revision_default" => $isPublished,
+        ])
+        ->condition('vid', $vid)
+        ->execute();
+    }
   }
 
   /**

--- a/docroot/modules/custom/bos_migration/src/MigrationPrepareRow.php
+++ b/docroot/modules/custom/bos_migration/src/MigrationPrepareRow.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Drupal\bos_migration;
+
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateSkipRowException;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\MigrateSourceInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\Core\Database\Database;
+
+class MigrationPrepareRow {
+
+  protected $row;
+  protected $source;
+  protected $migration;
+
+  /**
+   * MigrationProcessRow constructor.
+   *
+   * @param \Drupal\migrate\Row $row
+   *   The current row being processed
+   * @param \Drupal\migrate\Plugin\MigrateSourceInterface $source
+   *   The source object.
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration object.
+   */
+  public function __construct(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
+    $this->row = $row;
+    $this->source = $source;
+    $this->migration = $migration;
+  }
+
+  /**
+   * Raises a skipMigration event if d7 revision is a draft.
+   *
+   * Called from bos_migration.module.
+   *
+   * @return bool
+   *   True to continue processing.
+   * @throws \Drupal\migrate\MigrateException
+   *   If error found.
+   * @throws \Drupal\migrate\MigrateSkipRowException
+   *   Thrown if row is to be skipped.
+   */
+  public function prepareNodeRevisionRow() {
+    // Doing this here, misses out a couple of later steps rather than using
+    // the SkipDraftRevision plugin.
+    if (empty($this->source->key())) {
+      throw new MigrateSkipRowException("vid is null.", false);
+    }
+    $key = unserialize($this->source->key());
+
+    if (empty($key["vid"])) {
+      throw new MigrateSkipRowException("vid is null.", false);
+    }
+    $vid = $key["vid"];
+
+    $workbench = self::findWorkbench($vid);
+    if (empty($workbench)) {
+      throw new MigrateSkipRowException("Workbench moderation not found.", false);
+    }
+    $nid = $workbench["nid"];
+
+    try {
+      return self::shouldProcessRow($nid, $vid, $workbench, []);
+    }
+    catch(MigrateSkipRowException $e) {
+      throw new MigrateSkipRowException($e->getMessage(), $e->getSaveToMap());
+    }
+    catch(\Exception $e) {
+      throw new MigrateException($e->getMessage(), $e->getCode(), $e->getPrevious(), MigrationInterface::MESSAGE_ERROR, MigrateIdMapInterface::STATUS_NEEDS_UPDATE);
+    }
+
+  }
+
+  /**
+   * Fetch moderation info for all moderated revisions of a node revision.
+   *
+   * @param int $vid
+   *   The node_revisionID (vid) to retrieve info on.
+   *
+   * @return array
+   *   Associative array of moderation info for node.
+   */
+  public static function findWorkbench($vid) {
+    $connection = Database::getConnection("default", "migrate");
+
+    $query = $connection->select("workbench_moderation_node_history", "history")
+      ->fields('history', [
+        "nid",
+        "vid",
+        "from_state",
+        "state",
+        "published",
+        "is_current"
+      ]);
+    $query->condition("vid", $vid);
+    $query->orderBy("hid", "DESC");
+
+    return $query->execute()->fetchAssoc();
+  }
+
+  /**
+   * Fetch the current revision of the node.
+   *
+   * @param int $nid
+   *   The nodeID to retrieve info on.
+   *
+   * @return array
+   *   Associative array of moderation info for node.
+   */
+  public static function findWorkbenchCurrent($nid) {
+    $connection = Database::getConnection("default", "migrate");
+
+    $query = $connection->select("workbench_moderation_node_history", "history")
+      ->fields('history', [
+        "nid",
+        "vid",
+        "from_state",
+        "state",
+        "published",
+        "is_current"
+      ]);
+    $query->condition("nid", $nid);
+    $query->condition("is_current", "1");
+
+    return $query->execute()->fetchAssoc();
+  }
+
+  /**
+   * Fetch the published revision of the node.
+   *
+   * @param int $nid
+   *   The nodeID to retrieve info on.
+   *
+   * @return array
+   *   Associative array of moderation info for node.
+   */
+  public static function findWorkbenchPublished($nid) {
+    $connection = Database::getConnection("default", "migrate");
+
+    $query = $connection->select("workbench_moderation_node_history", "history")
+      ->fields('history', [
+        "nid",
+        "vid",
+        "from_state",
+        "state",
+        "published",
+        "is_current"
+      ]);
+    $query->condition("nid", $nid);
+    $query->condition("published", "1");
+
+    return $query->execute()->fetchAssoc();
+  }
+
+  /**
+   * Tests to see if the row should be skipped.
+   *
+   * The row should be skipped if the d7 moderation state is draft, and the
+   * revision is not published and is not the current revision.
+   *
+   * @param int $nid
+   *   The nid for this node
+   * @param int $vid
+   *   The revision of the node to be "tested".
+   * @param array $workbench
+   *   Moderation info for each moderation-revision of this node-revision.
+   * @param array $properties
+   *   Control info for logging and process-mapping.
+   *
+   * @return bool
+   *   True to process row.
+   * @throws \Drupal\migrate\MigrateSkipRowException
+   *   Thrown if the revisions latest moderation state is "draft".
+   */
+  public static function shouldProcessRow(int $nid, int $vid, array $workbench = [], array $properties = []) {
+    if (empty($workbench)) {
+      $workbench = self::findWorkbench($vid);
+    }
+
+    $map = ((empty($properties["save_to_map"]) || $properties["save_to_map"] == "false") ? FALSE : TRUE);
+
+    if ($workbench['state'] != "published" && !$workbench['is_current']) {
+      $msg = $properties["message"] ?: NULL;
+      if (!empty($msg)) {
+        $msg = \Drupal::translation()->translate("@msg (nid:@nid / vid:@vid).", [
+          "@msg" => $msg,
+          "@nid" => $nid,
+          "@vid" => $vid,
+        ]);
+      }
+      throw new MigrateSkipRowException($msg, $map);
+    }
+
+    return TRUE;
+
+  }
+
+  public static function setNodeStatus($vid, $status) {
+    // node_field_revision
+    \Drupal::database()->update("node_field_data")
+      ->fields([
+        "status" => $status,
+      ])
+      ->condition('vid', $vid)
+      ->execute();
+
+    // node_field_revision
+    \Drupal::database()->update("node_field_revision")
+      ->fields([
+        "status" => $status,
+      ])
+      ->condition('vid', $vid)
+      ->execute();
+  }
+
+  public static function setModerationState($vid, $state) {
+    \Drupal::database()->update("content_moderation_state_field_data")
+      ->fields([
+        "moderation_state" => $state,
+      ])
+      ->condition('content_entity_revision_id', $vid)
+      ->execute();
+
+    \Drupal::database()->update("content_moderation_state_field_revision")
+      ->fields([
+        "moderation_state" => $state,
+      ])
+      ->condition('content_entity_revision_id', $vid)
+      ->execute();
+  }
+
+  /**
+   * @param $nid
+   * @param $vid
+   * @param $isPublished
+   */
+  public static function setCurrentRevision($nid, $vid, $isPublished) {
+    // Set the node vid to be the current revision.
+    // Table: node
+    \Drupal::database()->update("node")
+      ->fields([
+        "vid" => $vid,
+      ])
+      ->condition('nid', $nid)
+      ->execute();
+
+    // Copy current rev of node_field_revision into node_field_data.
+    // Table: node_field_data
+    $qstring = "UPDATE node_field_data dat
+                      INNER JOIN node_field_revision rev ON dat.nid = rev.nid  
+                      SET
+                        dat.vid = rev.vid,
+                        dat.status = rev.status,
+                        dat.title = rev.title,
+                        dat.uid = rev.uid,
+                        dat.created = rev.created,
+                        dat.changed = rev.changed,
+                        dat.promote = rev.promote,
+                        dat.sticky = rev.sticky,
+                        dat.default_langcode = rev.default_langcode,
+                        dat.revision_translation_affected = rev.revision_translation_affected,
+                        dat.published_at = rev.published_at,
+                        dat.content_translation_source = rev.content_translation_source,
+                        dat.content_translation_outdated = rev.content_translation_outdated
+                        WHERE rev.nid = " . $nid . " 
+                            AND rev.langcode = 'und' 
+                            AND rev.vid = " . $vid . ";";
+    \Drupal::database()->query($qstring)->execute();
+
+    // Only set the revision default to be true if this revision is pub.
+    // Table: node_revision
+    \Drupal::database()->update("node_revision")
+      ->fields([
+        "revision_default" => $isPublished,
+      ])
+      ->condition('vid', $vid)
+      ->execute();
+  }
+
+  public static function setCurrentModerationRevision($nid, $vid, $isPublished) {
+    // Get the id and rev_id for the moderation state.
+    $query = \Drupal::database()->select("content_moderation_state_field_revision", "rev")
+      ->fields("rev", ["id", "revision_id"]);
+    $query->condition('content_entity_id', $nid);
+    $query->condition('content_entity_revision_id', $vid);
+
+    if ($rev = $query->execute()->fetchAll()[0]) {
+
+      // Table: content_moderation_state_field_data.
+      $qstring = "UPDATE drupal.content_moderation_state_field_data dat
+                      INNER JOIN content_moderation_state_field_revision rev ON dat.id = rev.id  
+                      SET
+                        dat.id = rev.id,
+                        dat.revision_id = rev.revision_id,
+                        dat.langcode = rev.langcode,
+                        dat.uid = rev.uid,
+                        dat.workflow = rev.workflow,
+                        dat.moderation_state = rev.moderation_state,
+                        dat.content_entity_type_id = rev.content_entity_type_id,
+                        dat.content_entity_id = rev.content_entity_id,
+                        dat.content_entity_revision_id = rev.content_entity_revision_id,
+                        dat.default_langcode = rev.default_langcode,
+                        dat.revision_translation_affected = rev.revision_translation_affected
+                      WHERE rev.id = " . $rev->id . " 
+                            AND rev.langcode = 'und' 
+                            and rev.revision_id = " . $rev->revision_id . ";";
+      \Drupal::database()->query($qstring)->execute();
+
+      $qstring = "UPDATE drupal.content_moderation_state dat
+                      INNER JOIN content_moderation_state_field_revision rev ON dat.id = rev.id AND dat.revision_id = rev.revision_id 
+                      SET
+                        dat.id = rev.id,
+                        dat.revision_id = rev.revision_id,
+                        dat.langcode = rev.langcode
+                      WHERE rev.id = " . $rev->id . "
+                            AND rev.langcode = 'und'
+                            and rev.revision_id = " . $rev->revision_id . ";";
+      \Drupal::database()->query($qstring)->execute();
+
+      // Table: node_revision
+      \Drupal::database()->update("content_moderation_state_revision")
+        ->fields([
+          "revision_default" => $isPublished,
+        ])
+        ->condition('id', $rev->id)
+        ->condition('revision_id', $rev->revision_id)
+        ->execute();
+    }
+
+  }
+
+
+}

--- a/docroot/modules/custom/bos_migration/src/Plugin/migrate/process/SkipDraftRevision.php
+++ b/docroot/modules/custom/bos_migration/src/Plugin/migrate/process/SkipDraftRevision.php
@@ -58,10 +58,10 @@ class SkipDraftRevision extends ProcessPluginBase {
       $row->workbench = $workbench;
       return $value;
     }
-    catch(MigrateSkipRowException $e) {
+    catch (MigrateSkipRowException $e) {
       throw new MigrateSkipRowException($e->getMessage(), $e->getSaveToMap());
     }
-    catch(Error $e) {
+    catch (Error $e) {
       throw new MigrateException($e->getMessage(), $e->getCode(), $e->getPrevious(), MigrationInterface::MESSAGE_ERROR, MigrateIdMapInterface::STATUS_NEEDS_UPDATE);
     }
 

--- a/docroot/modules/custom/bos_migration/src/Plugin/migrate/process/SkipDraftRevision.php
+++ b/docroot/modules/custom/bos_migration/src/Plugin/migrate/process/SkipDraftRevision.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\bos_migration\Plugin\migrate\process;
 
+use Drupal\bos_migration\MigrationPrepareRow;
 use Drupal\migrate\MigrateException;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\MigrateSkipRowException;
@@ -9,7 +10,6 @@ use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
-use Drupal\Core\Database\Database;
 
 /**
  * Do not migrate (i.e. skip revisions with workbench status = draft).
@@ -48,35 +48,22 @@ class SkipDraftRevision extends ProcessPluginBase {
     //
     // If the moderation state in Drupal 7 is not Published, then don't migrate.
     // Be mindful that the latest revision coud be draft, so keep that.
+    $vid = $row->getSource()["vid"];
+
+    $workbench = MigrationPrepareRow::findWorkbench($vid);
     try {
-      $vid = $row->getSource()["vid"];
-      $connection = Database::getConnection("default", "migrate");
-      $query = $connection->select("workbench_moderation_node_history", "history")
-        ->fields('history', ["from_state", "state", "published", "is_current"]);
-      $query->condition("vid", $vid);
-      $query->orderBy("hid", "DESC");
-      $workbench = $query->execute()->fetchAssoc();
-
-      $map = ((empty($this->configuration["save_to_map"]) || $this->configuration["save_to_map"] == "false") ? FALSE : TRUE);
-
-      if ($workbench['state'] != "published" && !$workbench['is_current']) {
-        $msg = $this->configuration["message"] ?: NULL;
-        if (!empty($msg)) {
-          $msg = \Drupal::translation()->translate("@msg (nid:@nid / vid:@vid).", [
-            "@msg" => $msg,
-            "@nid" => $row->getSource()["nid"],
-            "@vid" => $vid,
-          ]);
-        }
-        throw new MigrateSkipRowException($msg, $map);
-      }
+      $result = MigrationPrepareRow::shouldProcessRow($row->getSource()["nid"], $vid, $workbench, $this->configuration);
+      // Add the d7 workbench moderation data to the source so other plugins
+      // can use it in later processing.
+      $row->workbench = $workbench;
+      return $value;
     }
-    catch (Error $e) {
-      // Some other error.
+    catch(MigrateSkipRowException $e) {
+      throw new MigrateSkipRowException($e->getMessage(), $e->getSaveToMap());
+    }
+    catch(Error $e) {
       throw new MigrateException($e->getMessage(), $e->getCode(), $e->getPrevious(), MigrationInterface::MESSAGE_ERROR, MigrateIdMapInterface::STATUS_NEEDS_UPDATE);
     }
-    $row->_workbench = $workbench;
-    return $value;
 
   }
 

--- a/docroot/themes/custom/bos_admin/bos_admin.theme
+++ b/docroot/themes/custom/bos_admin/bos_admin.theme
@@ -334,8 +334,9 @@ function bos_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) 
         if ($chain[0]->id() == $form_state->getBuildInfo()['args'][0]->id()) {
 
           // Make the lineage into an array of strings.
+          $bundle[0] = ucwords(str_replace(["_", "-"], " ", $chain[0]->bundle()));
           $title[0] = "<div class='ce-pretty'>";
-          $title[] = "<h2>" . ucwords(str_replace(['-', '_'], " ", $chain[0]->bundle())) . ": <span class='ce-title'>" . $chain[0]->getTitle() . "</span> (nid " . $chain[0]->id() . ")" . "</h2>";
+          $title[] = "<h2>" . $bundle[0] . ": <span class='ce-title'>" . $chain[0]->getTitle() . "</span> (nid " . $chain[0]->id() . ")" . "</h2>";
           switch ($chain[1]->getEntityTypeId()) {
             case "node":
               $title[] = "<h3 class='ce-pretty'> > <span class='ce-title'>" . $chain[1]->getTitle() . "</span> (nid " . $chain[1]->id() . ")</h3>";
@@ -345,7 +346,7 @@ function bos_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) 
               foreach ($chain[1]->getFields() as $fieldName => $field) {
                 $crumb = ucwords(str_replace(['-', '_'], " ", $chain[1]->bundle() . (isset($chain[2]) ? " > " . $chain[2]->bundle() : '')));
                 if (preg_match('/^(field_).*?title/', $fieldName) && !empty($field->getValue()[0]['value'])) {
-                  $title[] = "<h3 class='ce-pretty'>" . $crumb . " > <span class='ce-title'>" . $field->getValue()[0]['value'] . "</span> (nid " . $chain[1]->id() . ")</h3>";
+                  $title[] = "<h3 class='ce-pretty'>Editing: " . $crumb . " > <span class='ce-title'>" . $field->getValue()[0]['value'] . "</span> (pid " . $chain[1]->id() . ")</h3>";
                   break;
                 }
               }
@@ -374,10 +375,10 @@ function bos_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) 
             ],
             "#button_type" => "danger",
             "#title" => new TranslatableMarkup("Return to @entity", [
-              "@entity" => ucwords($chain[0]->bundle()),
+              "@entity" => $bundle[0],
             ]),
             "#value" => new TranslatableMarkup("Return to @entity", [
-              "@entity" => ucwords($chain[0]->bundle()),
+              "@entity" => $bundle[0],
             ]),
             "#type" => "link",
             "#url" => Url::fromRoute("entity.node.canonical", [


### PR DESCRIPTION
Done.
This adds manual processes to migrate the D7 workbench moderation into the D8 content moderation.
- Migrates only published nodes.
- Does not migrate (copy) media.
- Sets published status correctly for revisions.
- Sets moderation states for previous revisions correctly.
- Sets current revision and current moderated revision correctly.