### PR TITLE
Remove default img referencing local url.

### DIFF
--- a/docroot/themes/custom/bos_theme/css/bos_theme_overrides.css
+++ b/docroot/themes/custom/bos_theme/css/bos_theme_overrides.css
@@ -877,15 +877,6 @@ What: Reset some funky CSS on featured post image.
 
 /*
 David:
-Where: node-post-listing.html.twig.
-What: Set a default background image in case no thumbnail provided or supplied image is missing.
- */
-.news-item-short-listing .thumb-wrapper.float-left {
-  background-image: url(https://boston.lndo.site/modules/custom/bos_content/modules/node_post/default_news.svg);
-}
-
-/*
-David:
 Where: media inside paragraph--columns.html.twig
 What: Fix the image to 200x200px.
  */


### PR DESCRIPTION
Related to https://github.com/CityOfBoston/boston.gov-d8/issues/627