### PR TITLE
CEX: Stop truncating Lottery listing PDFs.

### DIFF
--- a/config/default/views.view.metrolist_affordable_housing.yml
+++ b/config/default/views.view.metrolist_affordable_housing.yml
@@ -2289,7 +2289,7 @@ display:
           click_sort_column: uri
           type: link
           settings:
-            trim_length: 80
+            trim_length: null
             url_only: true
             url_plain: true
             rel: '0'


### PR DESCRIPTION
Fixes https://github.com/CityOfBoston/boston.gov-d8/issues/990