### PR TITLE
Allow missing titles for grid links.

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_link_collections/bos_link_collections.module
+++ b/docroot/modules/custom/bos_components/modules/bos_link_collections/bos_link_collections.module
@@ -119,9 +119,9 @@ function bos_link_collections_preprocess_paragraph(&$vars) {
     switch ($paragraph->bundle()) {
       case 'document':
         if ($vars['elements']['#view_mode'] == 'separated_title' || $vars['elements']['#view_mode'] == 'ribbon_link') {
-          if (!$paragraph->get('field_document')->isEmpty() && !$paragraph->get('field_title')->isEmpty()) {
+          if (!$paragraph->get('field_document')->isEmpty()) {
             $document = $paragraph->get('field_document')->getValue();
-            if ($paragraph->get('field_document')->isEmpty()) {
+            if ($paragraph->get('field_document')->isEmpty() || $paragraph->get('field_title')->isEmpty()) {
               $vars['title'] = _bos_core_get_file_name($document['0']['target_id']);
             }
             else {


### PR DESCRIPTION
Related to https://github.com/CityOfBoston/boston.gov-d8/issues/1086