### PR TITLE
Issue #1015: Department icons not centered

### DIFF
--- a/docroot/themes/custom/bos_theme/css/bos_theme_overrides.css
+++ b/docroot/themes/custom/bos_theme/css/bos_theme_overrides.css
@@ -782,12 +782,11 @@ What: Fixes the department icon to be 100px square. (Iterators issue #39)
 */
 @media screen and  (min-width: 980px) {
   .node-type-department-profile .department-icon {
-    padding: 13px 0 0 13px;
+    padding: 13px 0 0 18px;
   }
 }
 .node-department-profile .department-icon svg {
-  height: 76px;
-  width: 76px;
+  width: 90%;
 }
 @media screen and (min-width: 980px) and (max-width: 1300px) {
   .node-type-department-profile .department-icon {


### PR DESCRIPTION
Issue #1015 : Department icons not centered

- Removed height
- Changed width to from a pixel unit to a percentage
- Adjusted `left-padding` to push icons closer to the center.

*TODO: Pages like [this](http://boston.lndo.site/departments/intergovernmental-relations) overlap with the icons due because some words are too long to be broken into the next line. If we want to try and address this it, it should be in another ticket. Ps. The best we can try to do is to see if can change the font-size on those title elements.