### PR TITLE
Revert Issue #1015: Department icons not centered

### DIFF
--- a/docroot/themes/custom/bos_theme/css/bos_theme_overrides.css
+++ b/docroot/themes/custom/bos_theme/css/bos_theme_overrides.css
@@ -782,11 +782,12 @@ What: Fixes the department icon to be 100px square. (Iterators issue #39)
 */
 @media screen and  (min-width: 980px) {
   .node-type-department-profile .department-icon {
-    padding: 13px 0 0 18px;
+    padding: 13px 0 0 13px;
   }
 }
 .node-department-profile .department-icon svg {
-  width: 90%;
+  height: 76px;
+  width: 76px;
 }
 @media screen and (min-width: 980px) and (max-width: 1300px) {
   .node-type-department-profile .department-icon {


### PR DESCRIPTION
Reverting Issue #1015 from `develop` and `master`