### PR TITLE
Backend configs for mnl entity.

### DIFF
--- a/config/default/ape.settings.yml
+++ b/config/default/ape.settings.yml
@@ -1,5 +1,5 @@
 alternatives: "<front>\r\n/metrolist/lottery-and-resale"
-exclusions: "/cityscore/totals/latest.json\r\n/api/v2/public-notices"
+exclusions: "/cityscore/totals/latest.json\r\n/api/v2/public-notices\r\n/rest/recollect\r\n/rest/mnl/*\r\n/mnl/*"
 lifetime:
   alternatives: 300
   301: 2592000

--- a/config/default/core.base_field_override.node.neighborhood_lookup.promote.yml
+++ b/config/default/core.base_field_override.node.neighborhood_lookup.promote.yml
@@ -1,0 +1,22 @@
+uuid: fb9b6f75-c44a-4ab6-9173-68b6d680dab8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.neighborhood_lookup
+id: node.neighborhood_lookup.promote
+field_name: promote
+entity_type: node
+bundle: neighborhood_lookup
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/node.type.neighborhood_lookup.yml
+++ b/config/default/node.type.neighborhood_lookup.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 _core:
   default_config_hash: E5hOXFff1HHAyGJcjuqDYa-1Xod5CebstRKi1VL35mI
 name: 'Neighborhood Lookup'

--- a/config/default/pathauto.pattern.my_neighborhood_lookup_so_can_disable_cache_in_ape_.yml
+++ b/config/default/pathauto.pattern.my_neighborhood_lookup_so_can_disable_cache_in_ape_.yml
@@ -1,0 +1,22 @@
+uuid: 5b100b93-5b1c-4ddc-b15d-ac57dd51079e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: my_neighborhood_lookup_so_can_disable_cache_in_ape_
+label: 'My Neighborhood Lookup (so can disable cache in APE)'
+type: 'canonical_entities:node'
+pattern: 'mnl/[node:title]'
+selection_criteria:
+  221752ea-77fe-4162-9c3a-00bebf856cfd:
+    id: node_type
+    bundles:
+      neighborhood_lookup: neighborhood_lookup
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 221752ea-77fe-4162-9c3a-00bebf856cfd
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/default/rabbit_hole.behavior_settings.node_type_neighborhood_lookup.yml
+++ b/config/default/rabbit_hole.behavior_settings.node_type_neighborhood_lookup.yml
@@ -1,0 +1,11 @@
+uuid: a5773c45-bfff-4b3b-8076-47d4a9499b1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.neighborhood_lookup
+id: node_type_neighborhood_lookup
+action: page_redirect
+allow_override: 0
+redirect: /
+redirect_code: 301

--- a/config/default/system.performance.yml
+++ b/config/default/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 2592000
+    max_age: 31536000
 css:
   preprocess: false
   gzip: true

--- a/docroot/modules/custom/bos_components/modules/bos_mnl/src/Controller/MNLRest.php
+++ b/docroot/modules/custom/bos_components/modules/bos_mnl/src/Controller/MNLRest.php
@@ -10,6 +10,59 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * MNLRest class for endpoint.
+ *
+ * All POSTS to endpoint must have format:
+ *   /rest/mnl/YYY?api_key=XXX
+ *   Where YYYY is one of 'update', 'import' or 'manual'.
+ *   Where api_key XXX is the token defined at /admin/config/services/mnl.
+ *
+ * Note: 'import' and 'update' endpoint usage must include a json string in the
+ *   body in the format:
+ *   [
+ *     {"sam_address_id":123,"full_address":"address","data": jsonstring"},
+ *     {"sam_address_id":123,"full_address":"address","data": jsonstring"}
+ *   ]
+ *   The 'jsonstring' must be a valid json object in string form and can contain
+ *   any data provided it represents a single record and can be decoded by
+ *   PHP's json_decode function.
+ *
+ * Note: provide a querystring for "manual" endpoint in format:
+ *   ?api_key=XXXXX&path=/path-on-server/file.json&limit=N&mode=import
+ *   Required:
+ *     'path' is path on remote server (or local container) to import file.
+ *   Optional:
+ *     'limit' process the first N records in the import file (defaults all).
+ *     'mode' can be either 'import' or 'update' (defaults to 'update').
+ *
+ * Note:
+ *  - UPDATE updates "full address" and "data" for SAM records in DB with
+ *    "full address" and "data" from records with a matchin "sam_address_id"
+ *    from the json payload. New records will be created if an existing
+ *    "sam_address_id" is not found in the DB. If there are duplicate
+ *    "sam_address_id"s in the import, only the first of the duplicate records
+ *    will be processed. No records will be deleted or marked for deletion.
+ *  - IMPORT also updates "full address" and "data" for SAM records in DB with
+ *    "full address" and "data" from records with a matchin "sam_address_id"
+ *    from the json payload. New records will also be created if an existing
+ *    "sam_address_id" is not found in the DB. If there are duplicate
+ *    "sam_address_id"s in the import, only the first of the duplicate records
+ *    will be processed.  If the database contains a record (ie. a
+ *    "sam_address_id") which is not in the import file, then after the import
+ *    completes, those "orphaned" records will be cleaned, by removing them
+ *    from the database.
+ *
+ * Note: Actual updating and deleting (when done) will be handled by queues that
+ *   are processed overnight by a scheduled task, so the endpoint only queues
+ *   tasks for later execution, it does not actually change data itself.
+ *
+ * Benchmarks 16 May 2020:
+ *   - Acquia/AWS Uploaded 1.4GB file with 400,000 records in 12 secs.
+ *   - Drupal: 400,000 records queued in less than 00:03:30 (3.5 mins).
+ *   - mnl_import queue processes (local) so acquia will be 5-10x faster:
+ *        - processed 395,037 records with 5,000 updates in 10 mins
+ *        - processed 395,037 records with 395,037 updates in 15 mins
+ *        - processed 395,037 records with 395,037 inserts (new nodes) - 58 min
+ *        - processed 50 deletes in 10sec
  */
 class MNLRest extends ControllerBase {
 
@@ -68,10 +121,10 @@ class MNLRest extends ControllerBase {
       $data = json_decode(strip_tags($data), TRUE);
     }
     else {
-      \Drupal::queue('mnl_import')->deleteQueue();
       \Drupal::queue('mnl_cleanup')->deleteQueue();
       $path = \Drupal::request()->get("path");
       $limit = \Drupal::request()->get("limit");
+      $operation = (\Drupal::request()->get("mode") ?: "update");
       if (NULL != $path && file_exists($path)) {
         $data = file_get_contents($path);
         $data = json_decode($data);
@@ -111,15 +164,13 @@ class MNLRest extends ControllerBase {
       }
 
       elseif ($operation == "import") {
-        $queue = \Drupal::queue('mnl_import');
-      }
-
-      elseif ($operation == "manual") {
-        $queue = \Drupal::queue('mnl_import');
+        $queue_name = 'mnl_import';
+        $queue = \Drupal::queue($queue_name);
       }
 
       elseif ($operation == "update") {
-        $queue = \Drupal::queue('mnl_update');
+        $queue_name = 'mnl_update';
+        $queue = \Drupal::queue($queue_name);
       }
 
       else {
@@ -136,9 +187,7 @@ class MNLRest extends ControllerBase {
           $queue->createItem($items);
         }
         \Drupal::logger("mnl import")
-          ->info("[0] REST $operation Import loaded " . count($data) . " SAM records into mnl_import queue.");
-        \Drupal::logger("mnl import")
-          ->info("[0] mnl_import queue now contains " . $queue->numberOfItems() . " SAM records to be processed.");
+          ->info("[0] REST payload contained " . number_format(count($data), 0) . " SAM records. <br>Loaded " . number_format($queue->numberOfItems()) . " records with unique SAM ID's into queue $queue_name");
 
         $response_array = [
           'status' => $operation . ' complete - ' . count($data) . ' items queued',

--- a/docroot/modules/custom/bos_components/modules/bos_mnl/src/Form/MNLSettingsForm.php
+++ b/docroot/modules/custom/bos_components/modules/bos_mnl/src/Form/MNLSettingsForm.php
@@ -33,6 +33,9 @@ class MNLSettingsForm extends ConfigFormBase {
     $config = $this->config('bos_mnl.settings');
     $form = [
       '#tree' => TRUE,
+      'label1' => [
+        "#markup" => "<h3>This module exposes REST endpoints at <b><i>/rest/mnl/xxxx</i>.</b></h3><p>See documentation below for REST endpoint syntax.</p>"
+      ],
       'mnl_admin' => [
         '#type' => 'fieldset',
         '#title' => 'MNL API Endpoint',
@@ -44,6 +47,52 @@ class MNLSettingsForm extends ConfigFormBase {
           '#default_value' => $config->get('auth_token'),
           '#required' => FALSE,
         ],
+      ],
+      'label2' => [
+        "#markup" => "<h3>Notes:</h3><ol><li>The REST endpoint merely loads data into a queue.</li>
+        <li>To perform and automate the update of MNL/SAM entities/nodes for use by the MNL module, 2 scheduled tasks must be created.<br><ul><li>The first task should execute the following command:<pre>drush queue:run mnl_import &> /dev/null && drush queue:run mnl_cleanup &> /dev/null</pre></li><li>and the second task should execute<pre>drush queue:run mnl_update &> /dev/null</pre></li></ul>Timing for scheduling those tasks should be some time after the expected completion of data submission via the REST endpoint.</li></ol>"
+      ],
+      'label3' => [
+        "#markup" => "<h4>If the scheduled tasks above are not created then the website will not be updated until the commands above are run manually.</h4>"
+      ],
+      'label4' => [
+        "#markup" => "<br><hr><h3>Documentation:</h3>
+All POSTS to endpoint must have format:
+  <ul><pre>/rest/mnl/YYY?api_key=XXX</pre></ul>
+  <ul><li>Where YYYY is one of 'update', 'import' or 'manual'.</li>
+  <li>Where api_key XXX is the <i><b>API KEY / token</b></i> defined above.</li></ul><br>
+'import' and 'update' endpoint usage must include a json string in the
+  body in the format:
+<ul><pre>[
+    {\"sam_address_id\":123,\"full_address\":\"address\",\"data\":jsonstring\"},
+    {\"sam_address_id\":123,\"full_address\":\"address\",\"data\":jsonstring\"}
+]</pre></ul>
+  <ul><li>The 'jsonstring' must be a valid json object in string form and can contain
+  any data provided it represents a single record and can be decoded by
+  PHP's json_decode function.</li></ul><br>
+'manual' endpoint requires no body (any body will be ignored) but must have an extended querystring in the format:
+  <ul><pre>?api_key=XXX&path=/path-on-server/file.json&limit=N&mode=ZZZ</pre></ul>
+  <i>Required:</i>
+    <ul><li>'path' is path on remote server (or local container) to import file.</li></ul>
+  <i>Optional:</i>
+    <ul><li>'limit' process the first N records in the import file (defaults all).</li>
+    <li>'mode' ZZZ can be either 'import' or 'update' (defaults to 'update').</li></ul>
+<b>Note:</b>
+ <ul><li><b>UPDATE</b> updates \"full address\" and \"data\" of SAM records in the DB with
+   \"full address\" and \"data\" from queued records with a matching \"sam_address_id\"
+   from the json payload. New records will be created if an existing
+   \"sam_address_id\" is not found in the DB. If there are duplicate
+   \"sam_address_id\"s in the json payload, only the first one of the duplicate records
+   will be processed and the rest will be skipped. No records will be deleted or marked for deletion.</li>
+ <li><b>IMPORT</b> also updates \"full address\" and \"data\" of SAM records in the DB with
+   \"full address\" and \"data\" from queued records with a matching \"sam_address_id\"
+   from the json payload. New records will also be created if an existing
+   \"sam_address_id\" is not found in the DB. If there are duplicate
+   \"sam_address_id\"s in the json payload, only the first one of the duplicate records
+   will be processed and the rest will be skipped.  If the database contains a record (ie. a
+   \"sam_address_id\") which is not in the import file, then after the import
+   completes, those \"orphaned\" records will be cleaned, by removing them
+   from the database.</li></ul>"
       ],
     ];
     return parent::buildForm($form, $form_state);

--- a/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLDeleteAll.php
+++ b/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLDeleteAll.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\bos_core\Plugin\QueueWorker;
+namespace Drupal\bos_mnl\Plugin\QueueWorker;
 
 use Drupal;
 use Drupal\Core\Queue\QueueWorkerBase;

--- a/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLProcessCleanup.php
+++ b/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLProcessCleanup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\bos_core\Plugin\QueueWorker;
+namespace Drupal\bos_mnl\Plugin\QueueWorker;
 
 use Drupal;
 use Drupal\Core\Queue\QueueWorkerBase;
@@ -92,13 +92,13 @@ class MNLProcessCleanup extends QueueWorkerBase {
       ->info("
         [2] Queue Process Results:<br>
         == Start Condition ==================<br>
-        Entities in DB at start      " . $this->stats["pre-entities"] . "<br>
-        mnl_cleanup queue at start   " . $this->stats["queue"] . "<br>
+        Entities in DB at start      " . number_format($this->stats["pre-entities"], 0) . "<br>
+        mnl_cleanup queue at start   " . number_format($this->stats["queue"], 0) . "<br>
         == Queue Processing =================<br>
-        Removed entities             " . $this->stats["processed"] . "<br>
+        Removed entities             " . number_format($this->stats["processed"], 0) . "<br>
         == Result ============================<br>
-        Entities in DB at end        " . $this->stats["post-entities"] . "<br>
-        mnl_cleanup queue at end     " . $this->queue->numberOfItems() . "<br>
+        Entities in DB at end        " . number_format($this->stats["post-entities"], 0) . "<br>
+        mnl_cleanup queue at end     " . number_format($this->queue->numberOfItems(), 0) . "<br>
         == Runtime ===========================<br>
         processing time: " . gmdate("H:i:s", strtotime("now") - $this->stats["starttime"]) . "<br>
       ");

--- a/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLProcessImport.php
+++ b/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLProcessImport.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\bos_core\Plugin\QueueWorker;
+namespace Drupal\bos_mnl\Plugin\QueueWorker;
 
 use Drupal;
 use Drupal\node\Entity\Node;
@@ -108,21 +108,21 @@ class MNLProcessImport extends QueueWorkerBase {
       ->info("
         [1] Queue Process Results:<br>
         == Start Condition ==================<br>
-        Entities in DB at start       " . $this->stats["pre-entities"] . "<br>
-        Cache (unique SAM's) at start " . $this->stats["cache"] . "<br>
-        mnl_import queue at start     " . $this->stats["queue"] . "<br>
+        Entities in DB at start       " . number_format($this->stats["pre-entities"], 0) . "<br>
+        Cache (unique SAM's) at start " . number_format($this->stats["cache"], 0) . "<br>
+        mnl_import queue at start     " . number_format($this->stats["queue"], 0) . "<br>
         == Queue Processing =================<br>
-        New entities created          " . $this->stats["inserted"] . "<br>
-        Updated entities              " . $this->stats["updated"] . "<br>
-        Unchanged entities            " . $this->stats["unchanged"] . "<br>
-        Entities sent to be cleaned   " . $this->stats["cleanup"] . "<br>
-        Duplicate SAM ID's found      " . $this->stats["duplicateSAM"] . "<br>
+        New entities created          " . number_format($this->stats["inserted"], 0) . "<br>
+        Updated entities              " . number_format($this->stats["updated"], 0) . "<br>
+        Unchanged entities            " . number_format($this->stats["unchanged"], 0) . "<br>
+        Entities sent to be cleaned   " . number_format($this->stats["cleanup"], 0) . "<br>
+        Duplicate SAM ID's found      " . number_format($this->stats["duplicateSAM"], 0) . "<br>
         == Result ============================<br>
-        Entities processed            " . $this->stats["processed"] . "<br>
-        Entities in DB at end         " . $this->stats["post-entities"] . "<br>
-        Cache (unique SAM's) at end   " . count($this->cache) . "<br>
-        mnl_import queue at end       " . $this->queue->numberOfItems() . "<br>
-        mnl_cleanup queue at end      " . $cleanup->numberOfItems() . "<br>
+        Entities processed            " . number_format($this->stats["processed"], 0) . "<br>
+        Entities in DB at end         " . number_format($this->stats["post-entities"], 0) . "<br>
+        Cache (unique SAM's) at end   " . number_format(count($this->cache), 0) . "<br>
+        mnl_import queue at end       " . number_format($this->queue->numberOfItems(), 0) . "<br>
+        mnl_cleanup queue at end      " . number_format($cleanup->numberOfItems(), 0) . "<br>
         == Runtime ===========================<br>
         processing time: " . gmdate("H:i:s", strtotime("now") - $this->stats["starttime"]) . "<br>
       ");

--- a/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLProcessUpdate.php
+++ b/docroot/modules/custom/bos_components/modules/bos_mnl/src/Plugin/QueueWorker/MNLProcessUpdate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\bos_core\Plugin\QueueWorker;
+namespace Drupal\bos_mnl\Plugin\QueueWorker;
 
 use Drupal;
 use Drupal\node\Entity\Node;
@@ -92,19 +92,19 @@ class MNLProcessUpdate extends QueueWorkerBase {
       ->info("
         [1] Queue Process Results:<br>
         == Start Condition ==================<br>
-        Entities in DB at start       " . $this->stats["pre-entities"] . "<br>
-        Cache (unique SAM's) at start " . $this->stats["cache"] . "<br>
-        mnl_update queue at start     " . $this->stats["queue"] . "<br>
+        Entities in DB at start       " . number_format($this->stats["pre-entities"], 0) . "<br>
+        Cache (unique SAM's) at start " . number_format($this->stats["cache"], 0) . "<br>
+        mnl_update queue at start     " . number_format($this->stats["queue"], 0) . "<br>
         == Queue Processing =================<br>
-        New entities created          " . $this->stats["inserted"] . "<br>
-        Updated entities              " . $this->stats["updated"] . "<br>
-        Unchanged entities            " . $this->stats["unchanged"] . "<br>
-        Duplicate SAM ID's found      " . $this->stats["duplicateSAM"] . "<br>
+        New entities created          " . number_format($this->stats["inserted"], 0) . "<br>
+        Updated entities              " . number_format($this->stats["updated"], 0) . "<br>
+        Unchanged entities            " . number_format($this->stats["unchanged"], 0) . "<br>
+        Duplicate SAM ID's found      " . number_format($this->stats["duplicateSAM"], 0) . "<br>
         == Result ============================<br>
-        Entities processed            " . $this->stats["processed"] . "<br>
-        Entities in DB at end         " . $this->stats["post-entities"] . "<br>
-        Cache (unique SAM's) at end   " . count($this->cache) . "<br>
-        mnl_update queue at end       " . $this->queue->numberOfItems() . "<br>
+        Entities processed            " . number_format($this->stats["processed"], 0) . "<br>
+        Entities in DB at end         " . number_format($this->stats["post-entities"], 0) . "<br>
+        Cache (unique SAM's) at end   " . number_format(count($this->cache), 0) . "<br>
+        mnl_update queue at end       " . number_format($this->queue->numberOfItems(), 0) . "<br>
         == Runtime ===========================<br>
         processing time: " . gmdate("H:i:s", strtotime("now") - $this->stats["starttime"]) . "<br>
       ");


### PR DESCRIPTION
- [ ] exclude mnl node from caching
- [ ] create default url for mnl nodes and redirect url to frontpage
- [ ] increase cache TTL to 1 year ([acquia recommendation](https://support.acquia.com/hc/en-us/articles/360005311513--Drupal-8-Acquia-Purge-cache-tags-invalidation-#howistag-basedcacheinvalidationsupportedonacquiacloud?)).