### PR TITLE
Invalidates caches for all pages with alerts, when alerts are updated.

### DIFF
--- a/config/default/views.view.emergency_alerts.yml
+++ b/config/default/views.view.emergency_alerts.yml
@@ -29,8 +29,12 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 0
+          results_lifespan_custom: 0
+          output_lifespan: 60
+          output_lifespan_custom: 0
       query:
         type: views_query
         options:

--- a/config/default/views.view.site_alerts.yml
+++ b/config/default/views.view.site_alerts.yml
@@ -440,8 +440,12 @@ display:
       relationships: {  }
       display_comment: ''
       cache:
-        type: tag
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 0
+          results_lifespan_custom: 0
+          output_lifespan: 60
+          output_lifespan_custom: 0
       filters:
         status:
           value: '1'
@@ -985,8 +989,12 @@ display:
         type: none
         options: {  }
       cache:
-        type: none
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 0
+          results_lifespan_custom: 0
+          output_lifespan: 60
+          output_lifespan_custom: 0
     cache_metadata:
       max-age: -1
       contexts:

--- a/docroot/modules/custom/bos_core/bos_core.module
+++ b/docroot/modules/custom/bos_core/bos_core.module
@@ -1226,5 +1226,3 @@ function bos_core_entity_presave(EntityInterface $entity) {
 
   }
 }
-//
-//config:views.view.site_alerts

--- a/docroot/modules/custom/bos_core/bos_core.module
+++ b/docroot/modules/custom/bos_core/bos_core.module
@@ -23,6 +23,7 @@ use Drupal\Core\Render\Markup;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\core\Template\Attribute;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Cache\Cache;
 
 define('BOS_CORE_SVG_ELEMENTS', 'a altGlyph altGlyphDef altGlyphItem animate animateColor animateMotion animateTransform circle clipPath colo cursor defs desc ellipse feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix feDiffuseLighting feDisplacementMap feDistantLight feFlood feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage feMerge feMergeNode feMorphology feOffset fePointLight feSpecularLighting feSpotLight feTile feTurbulence filter font fon fon fon fon fon foreignObject g glyph glyphRef hkern image line linearGradient marker mask metadata missin mpath path pattern polygon polyline radialGradient rect script set stop style svg switch symbol text textPath title tref tspan use view vkern');
 
@@ -1211,5 +1212,19 @@ function bos_core_entity_presave(EntityInterface $entity) {
       }
     }
 
+    // Invalidate some nodes caches.
+    switch ($entity->get('moderation_state')->getString()) {
+      case "published":
+        if ($entity->getType() == "emergency_alert") {
+          Cache::invalidateTags(["config:views.view.emergency_alerts"]);
+        }
+        elseif ($entity->getType() == "site_alert") {
+          Cache::invalidateTags(["config:views.view.site_alerts"]);
+        }
+        break;
+    }
+
   }
 }
+//
+//config:views.view.site_alerts


### PR DESCRIPTION
This sets all site_alert and emergency_alert views to only cache output for 1 minute.  This is because content should be removed and shown on a schedule.
Also adds code to bos_core to invalidate caches when a site or emergency alert is updated.  The invalidation targets those nodes which have registered the view output in their cache-tags.
This should eliminate the need to refresh varnish caches manually on production when a site_alert or emergency_alert is created, updated, or removed.  We need to test if the cache is cleared when the alert expires (b/c an update is not actually performed so the hook in bos_core wont be fired - we will rely on the cachetag expiring after 1 min and this is unclear).