### PR TITLE
Re-enable email on metrolist listing form

### DIFF
--- a/config/default/webform.webform.metrolist_listing.yml
+++ b/config/default/webform.webform.metrolist_listing.yml
@@ -210,7 +210,7 @@ handlers:
     id: email
     label: 'New Submission Notice'
     handler_id: email
-    status: false
+    status: true
     conditions: {  }
     weight: 0
     settings:


### PR DESCRIPTION
Re-enable email on metrolist listing form