### PR TITLE
#618 - Make page body copy not required on all content types

### DIFF
--- a/config/default/field.field.node.article.body.yml
+++ b/config/default/field.field.node.article.body.yml
@@ -15,7 +15,7 @@ entity_type: node
 bundle: article
 label: 'Article Body'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/default/field.field.node.department_profile.body.yml
+++ b/config/default/field.field.node.department_profile.body.yml
@@ -15,7 +15,7 @@ entity_type: node
 bundle: department_profile
 label: 'Department Overview'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/default/field.field.node.event.body.yml
+++ b/config/default/field.field.node.event.body.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: event
 label: 'Event Body'
 description: 'Use this field to provide a longer description about the event.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/default/field.field.node.post.body.yml
+++ b/config/default/field.field.node.post.body.yml
@@ -15,7 +15,7 @@ entity_type: node
 bundle: post
 label: Body
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
Make page body copy not required on all content types: unset the body field requirement on article, department, event, posts.