### PR TITLE
Feature/#2080 - Image resizing issues

### DIFF
--- a/docroot/themes/custom/bos_theme/js/cob_ckeditor.boston.js
+++ b/docroot/themes/custom/bos_theme/js/cob_ckeditor.boston.js
@@ -9,17 +9,13 @@
 
 const x = window.matchMedia("(max-width: 1100px)");
 function screenSize(x) {
-  let changeHeight = document.querySelectorAll(".cob-ckeditor .cob-ckeditor-bg");
-
+  let changeHeight = document.querySelectorAll(":not(.no-resize) > div > .cob-ckeditor .cob-ckeditor-bg");
   if (x.matches) { // If media query matches.
     for (let i = 0; i < changeHeight.length; i++) {
-      if (changeHeight[i].parent().is(":not(.no-resize)")) {
         let show = changeHeight[i].getAttribute("data-cob-ckeditor");
         changeHeight[i].style.height = show - 100 + "px";
         changeHeight[i].style.minHeight = show - 100 + "px";
-      }
     }
-
   }
   else {
     x = window.matchMedia("(min-width: 1101px)");

--- a/docroot/themes/custom/bos_theme/js/cob_ckeditor.boston.js
+++ b/docroot/themes/custom/bos_theme/js/cob_ckeditor.boston.js
@@ -13,9 +13,11 @@ function screenSize(x) {
 
   if (x.matches) { // If media query matches.
     for (let i = 0; i < changeHeight.length; i++) {
-      let show = changeHeight[i].getAttribute("data-cob-ckeditor");
-      changeHeight[i].style.height = show - 100 + "px";
-      changeHeight[i].style.minHeight = show - 100 + "px";
+      if (changeHeight[i].parent().is(":not(.no-resize)")) {
+        let show = changeHeight[i].getAttribute("data-cob-ckeditor");
+        changeHeight[i].style.height = show - 100 + "px";
+        changeHeight[i].style.minHeight = show - 100 + "px";
+      }
     }
 
   }


### PR DESCRIPTION
Allow embed style images in the WYSIWYG to not auto-resize if they have a parent wrapper with the class of: ".no-resize".