### PR TITLE
Adhoc fix for container not being able ssh on new MacOs/Lando

### DIFF
--- a/scripts/.config.yml
+++ b/scripts/.config.yml
@@ -53,10 +53,10 @@ build:
       #         set to 'restore' (and provide backup location) to restore a local backup.
       #         set to 'none' to not import or create a new db (NOTE: new/changed configs will still be imported).
       # Tip: Develop environment has database in closest state to the github repo configs.
-      source: sync
+      source: restore
       # If you wish to use mycli and pspg tools in the container, set the next line to true.
       drush_alias: "@bostond8.dev"
-      backup_location: ""
+      backup_location: "/app/dump_bck.sql"
       host: boston_database_1
       port: 3306
       server_side_tools: false

--- a/scripts/cob_build_utilities.sh
+++ b/scripts/cob_build_utilities.sh
@@ -114,7 +114,7 @@ function clone_private_repo() {
   if [[ -z "${git_private_repo_local_dir}" ]]; then git_private_repo_local_dir="${REPO_ROOT}/tmprepo"; fi
 
   # Empty the folder if it exists.
-  if [[ -e "${git_private_repo_local_dir}" ]]; then rm -rf ${git_private_repo_local_dir}; fi
+#   if [[ -e "${git_private_repo_local_dir}" ]]; then rm -rf ${git_private_repo_local_dir}; fi
 
   # Clone the repo and merge
   printout "INFO" "Private repo: ${git_private_repo_repo} - Branch: ${git_private_repo_branch} - will be cloned into ${git_private_repo_local_dir}."
@@ -127,6 +127,7 @@ function clone_private_repo() {
   fi
 
   git clone -b ${git_private_repo_branch} ${REPO_LOCATION}${git_private_repo_repo} ${git_private_repo_local_dir} -q --depth 1
+  echo skipped
 
   if [[ $? -eq 0 ]]; then
     printout "SUCCESS" "Private repo cloned."

--- a/scripts/local/lando-build-drupal.sh
+++ b/scripts/local/lando-build-drupal.sh
@@ -288,7 +288,7 @@ elif [[ "${build_local_database_source}" == "restore" ]]; then
   printout "INFO" " -> This will take some time ..."
 
   printout "ACTION" "Restoring database."
-  (${drush_cmd} -y sql:drop --database=default >${setup_logs}/drush_site_install.log &&
+  (${drush_cmd} -y sql:drop --database=default >>${setup_logs}/drush_site_install.log &&
     ${drush_cmd} -y sql:cli --database=default <${build_local_database_backup_location} &&
     printout "SUCCESS" "Database has been restored.\n") || (printout "ERROR" "Database restore failed.\n" && exit 1)
 
@@ -317,7 +317,7 @@ elif [[ "${build_local_database_source}" == "sync" ]]; then
   printout "ACTION" "Copying database and content."
   # To be sure we eliminate all existing data we first drop the local DB, and then download a backup from the
   # remote server, and restore into the database container.
-  (${drush_cmd} -y sql:drop --database=default >${setup_logs}/drush_site_install.log &&
+  (${drush_cmd} -y sql:drop --database=default >>${setup_logs}/drush_site_install.log &&
     ${drush_cmd} -y sql:sync --skip-tables-key=common --structure-tables-key=common ${build_local_database_drush_alias} @self >>${setup_logs}/drush_site_install.log &&
     printout "SUCCESS" "Site is installed with database and content from remote environment.\n") || (printout "ERROR" "Fail - Database sync" "Check ${setup_logs}/drush_site_install.log for issues.\n" && exit 1)
 fi


### PR DESCRIPTION
<!--- This is an adhoc fix for the issue I have on my Mac (Phill) --->

# <h1 style="color:red">**DO NOT MERGE**</span>

Issue: On new MacOS/Lando (3.14) I have an issue where the container is unable to connect via ssh to download the staging database. We could not figure out a fix for the issue so David came with this workaround for now:

- After having attempted to start the service, do this because this will mount the container so you can ssh into later
- Download the DB needed (staging) from the Acquia console
- Unzip the downloaded DB, rename it (dump_bck) and copy it into the root of you local D8 repo.
- Git clone the D8 private repo into this repos root directory ... ```git clone git@github.com:CityOfBoston/boston.gov-d8-private.git setup/private```
- SSH into the container ```lando ssh``` and ```cd scripts/local```
- Run ``` ./lando-build-drupal.sh ``` script