### PR TITLE
#1356 - Remove the "preview" button under the "moderation state" - re…

### DIFF
--- a/docroot/modules/custom/bos_core/bos_core.module
+++ b/docroot/modules/custom/bos_core/bos_core.module
@@ -50,6 +50,12 @@ function bos_core_help($route_name, RouteMatchInterface $route_match) {
  */
 function bos_core_form_alter(&$form, $form_state, $form_id) {
   $form['#attributes']['novalidate'] = 'novalidate';
+
+  // #1356 - Removed preview button for all roles except administrators
+  if (isset($form['actions']['preview']['#access'])
+    && !in_array('administrator', \Drupal::currentUser()->getRoles())) {
+    $form['actions']['preview']['#access'] = false;
+  }
 }
 
 /**


### PR DESCRIPTION
…moved access to the preview form action for all roles except administrators.