### PR TITLE
[RELEASE TO STAGE] - Release/2021-11-29_a (#2265)

### DIFF
--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/css/node_bh_project.css
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/css/node_bh_project.css
@@ -111,9 +111,14 @@
 
 .bh-project-type {
   display: flex;
-  flex-flow: row nowrap;
+  flex-flow: column nowrap;
+  align-items: flex-start;
 }
 
+.bh-project-type .bh-project-info {
+  display: flex;
+  flex-flow: row nowrap;
+}
 
 .bh-project-type .project-type-icon {
   display: flex;
@@ -132,6 +137,11 @@
 .bh-project-type .br--w {
   border-color: #fff;
 }
+
+.bh-project-type .bh-project-cta a:hover {
+    color: #fff !important;
+}
+
 
 .bh-project-type .t--intro, .bh-project-type .t--subtitle {
   font-style: normal;

--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/node_buildinghousing.module
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/node_buildinghousing.module
@@ -13,6 +13,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\Entity\NodeType;
 use Drupal\node_buildinghousing\BuildingHousingUtils as BHUtils;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\views\ViewExecutable;
 use Drupal\node_buildinghousing\BuildingHousingUtils;
 
@@ -607,12 +608,14 @@ function _node_buildinghousing_build_render_project_meeting_notice(EntityInterfa
 
     foreach ($meetings as $meetingId => $meeting) {
 
-//      $timeZoneAdjustment = new \DateTimeZone("Etc/GMT+10");
-      $timeZoneAdjustment = new \DateTimeZone("Etc/GMT+8");
       $startDate = \DateTime::createFromFormat('Y-m-d\TH:i:s', $meeting->field_bh_meeting_start_time->value);
-      $startDate->setTimezone($timeZoneAdjustment);
       $endDate = \DateTime::createFromFormat('Y-m-d\TH:i:s', $meeting->field_bh_meeting_end_time->value);
-      $endDate->setTimezone($timeZoneAdjustment);
+
+      //Fix for the odd timezone rendering being off by local GMT of -5 and -4(DST)
+      $hoursOffset = 5 - $startDate->format('I');
+      $dateOffset = \DateInterval::createFromDateString("$hoursOffset hours");
+      $startDate->sub($dateOffset);
+      $endDate->sub($dateOffset);
 
       if ($startDate->getTimestamp() > time()) {
 
@@ -755,6 +758,14 @@ function _node_buildinghousing_build_render_computed_project_type(EntityInterfac
       return [];
     }
 
+    if ($computedProjectType['label'] == 'Open Space') {
+      $vars['link_text'] = t('MORE INFO ON OPEN SPACE');
+      $vars['link_url'] = '/housing/grassroots-and-open-space-development';
+    }elseif ($computedProjectType['body'] == 'Housing - NHI') {
+      $vars['link_text'] = t('LEARN MORE AND APPLY');
+      $vars['link_url'] = '/departments/neighborhood-development/neighborhood-homes-initiative';
+    }
+
     // @TODO: Move to ent conf and set on term
     if ($computedProjectType['label'] == 'Abutter Sale' || $computedProjectType['label'] == 'For Sale') {
       $vars['label'] = t('For Sale');
@@ -808,7 +819,7 @@ function _node_buildinghousing_get_computed_project_type(EntityInterface $entity
     $data['label'] = is_string($mainType) ? $mainType : $mainType->getName();
   }
 
-  if ($subType) {
+  if ($subType && $projectTypeId) {
     $subType = $subType->getName();
     if ($subType == 'Mixed Use - Assisted' || $subType == 'Mixed Use - Market') {
       $data['body'] = 'Mixed Use';
@@ -1104,6 +1115,13 @@ function _node_buildinghousing_build_render_developer_info(EntityInterface $enti
       $vars['tags'][] = t('Women Owned Business');
     }
 
+  }
+
+  $projectPublicStage = $entity->get('field_bh_public_stage')->target_id
+    ? Term::load($entity->get('field_bh_public_stage')->target_id)->name->value : NULL;
+
+  if ($projectPublicStage == 'Not Active') {
+    return [];
   }
 
   return ['#markup' => \Drupal::theme()->render("bh_project_developer_info", $vars)];

--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/src/BuildingHousingUtils.php
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/src/BuildingHousingUtils.php
@@ -230,6 +230,7 @@ class BuildingHousingUtils
       && in_array($projectStatus, ['Active'])
       && in_array($projectStage, [
         'Under Agreement',
+        'Awarded',
         'Closing Underway'
       ])
     ) {

--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/src/Plugin/Field/FieldFormatter/EntityReferenceTaxonomyTermBSPublicStageFormatter.php
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/src/Plugin/Field/FieldFormatter/EntityReferenceTaxonomyTermBSPublicStageFormatter.php
@@ -378,12 +378,14 @@ class EntityReferenceTaxonomyTermBSPublicStageFormatter extends EntityReferenceF
 
       foreach ($meetings as $meetingId => $meeting) {
 
-        $timeZoneAdjustment = new \DateTimeZone("Etc/GMT+8");
-//        $timeZoneAdjustment = new \DateTimeZone("America/New_York");
         $startDate = \DateTime::createFromFormat('Y-m-d\TH:i:s', $meeting->field_bh_meeting_start_time->value);
-        $startDate->setTimezone($timeZoneAdjustment);
         $endDate = \DateTime::createFromFormat('Y-m-d\TH:i:s', $meeting->field_bh_meeting_end_time->value);
-        $endDate->setTimezone($timeZoneAdjustment);
+
+        //Fix for the odd timezone rendering being off by local GMT of -5 and -4(DST)
+        $hoursOffset = 5 - $startDate->format('I');
+        $dateOffset = \DateInterval::createFromDateString("$hoursOffset hours");
+        $startDate->sub($dateOffset);
+        $endDate->sub($dateOffset);
 
         if ($startDate->getTimestamp() > time()) {
           $event = $meeting->field_bh_event_ref->isEmpty() ? NULL : $meeting->field_bh_event_ref->referencedEntities()[0];
@@ -414,7 +416,7 @@ class EntityReferenceTaxonomyTermBSPublicStageFormatter extends EntityReferenceF
         }
         else {
           // $label = t('PAST COMMUNITY MEETING');
-          $label = t('VIEW WEBEX RECORDINGS');
+          $label = t('VIEW MEETING RECORDINGS');
           $icon = \Drupal::theme()->render("bh_icons", [
             'type' => 'timeline-calendar',
             'fill' => 'cb'

--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/templates/snippets/bh-project-timeline.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/templates/snippets/bh-project-timeline.html.twig
@@ -21,9 +21,6 @@
   <h2 class="sh cl sh-title p-t400">{{ label }}</h2>
 {% endif %}
 <div class="bh-project-timeline g m-v600 p-a300">
-  {% if isDevelopment %}
-  <p class="t--subinfo">We're funding this project to create more affordable housing. We don't own this land.</p>
-  {% endif %}
   {{ items }}
 </div>
 

--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/templates/snippets/bh-project-type.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/templates/snippets/bh-project-type.html.twig
@@ -9,28 +9,39 @@
  * - body: The content value of the item.
  * - bgColor: The background color for this item.
  * - icon: The icon value of the detail item.
+ * - link_url: Call to action url
+ * - link_text: Call to action text
  * - classes: Array of classes to be applied to detail, icon, label, and body
  *   elements.
  */
 #}
 
 
-
 <div class="bh-project-type bg--cb m-b600 p-a300" style="background-color: {{ bgColor }}">
-  <div class="">
-    {#        <img src="https://patterns.boston.gov/images/global/icons/experiential/triple-decker.svg">#}
-    <div typeof="foaf:Image" class="project-type-icon">
-      {{ icon }}
+  <div class="bh-project-info">
+
+    <div class="">
+      {# <img src="https://patterns.boston.gov/images/global/icons/experiential/triple-decker.svg"> #}
+      <div typeof="foaf:Image" class="project-type-icon">
+        {{ icon }}
+      </div>
     </div>
+
+    <div class="">
+      {% if title %}
+        <div class="t--subinfo t--w br br-b100 br-g100 br--w">{{ title }}</div>
+      {% endif %}
+      <h4 class="t--w m-t300 m-b100">{{ label }}</h4>
+      <div class="t--subtitle t--sans t-upper t--w">{{ body }}</div>
+    </div>
+
   </div>
 
-  <div class="">
-    {% if title %}
-      <div class="t--subinfo t--w br br-b100 br-g100 br--w">{{ title }}</div>
-    {% endif %}
-    <h4 class="t--w m-t300 m-b100">{{ label }}</h4>
-    <div class="t--subtitle t--sans t-upper t--w">{{ body }}</div>
-  </div>
+  {% if link_url and link_text %}
+    <div class="m-t200 bh-project-cta">
+      <a href="{{ link_url }}" class="btn btn--b btn--w" style="color: {{ bgColor }};">{{ link_text }}</a>
+    </div>
+  {% endif %}
 
 </div>
 

--- a/docroot/themes/custom/bos_theme/dist/js/all.js
+++ b/docroot/themes/custom/bos_theme/dist/js/all.js
@@ -321,7 +321,7 @@
 (function ($, Drupal, window, document) {
 
   'use strict';
-  if ($('.node-type-how-to').length || $('.node-type-tabbed-content').length) {
+  if ($('.node-type-tabbed-content').length) {
     $('#breadcrumb').prependTo('article');
   }
 


### PR DESCRIPTION
* #2218 - "Transactions grid" component display broken on "how-to" pages.
Remove old JS function that would copy and duplicate a breadcrumb element to any and every article element.

* #2089 - If Housing 'Project Type' is blank, leave sub-type blank in sidebar

* #1763 - Add Button to Open Space + Housing: Homeownership Project Type Components

* #2078 - Make Disposition Projects in an "Awarded" stage show up as in "City Planning" ...

* #1971 - Remove "We're funding this project..." line of text from development-only fund...

* #2077 - Remove Developer Profile from Inactive Parcels

* #2077 - Remove Developer Profile from Inactive Parcels. Also including a fix for the DateTime issue on Meeting notices.