### PR TITLE
Fix for DND SF Syncing

### DIFF
--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/src/EventSubscriber/SalesforceBuildingHousingUpdateSubscriber.php
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/src/EventSubscriber/SalesforceBuildingHousingUpdateSubscriber.php
@@ -327,7 +327,7 @@ class SalesforceBuildingHousingUpdateSubscriber implements EventSubscriberInterf
 
           if ($project = $update->get('field_bh_project_ref')->referencedEntities()[0]) {
 
-            $projectName = basename($project->toUrl()) ?? 'unknown';
+            $projectName = basename($project->toUrl()->toString()) ?? 'unknown';
             $fileTypeToDirMappings = [
               'image/jpeg' => 'image',
               'JPEG' => 'image',
@@ -355,7 +355,7 @@ class SalesforceBuildingHousingUpdateSubscriber implements EventSubscriberInterf
               $fileName = $attachment['Name'];
             }
 
-            if (file_prepare_directory($storageDirPath, FILE_CREATE_DIRECTORY)) {
+            if (\Drupal::service('file_system')->prepareDirectory($storageDirPath, FileSystemInterface::CREATE_DIRECTORY)) {
               $destination = $storageDirPath . $fileName;
             }
             else {


### PR DESCRIPTION
Updated some deprecated functions for Drupal 9.X. Now using the file…_system service to prepare the directory for files, and added an explicit ->toString() on the URL object.