### PR TITLE
hotfix: add purger to config_split across environments

### DIFF
--- a/config/acquia_dev/purge.logger_channels.yml
+++ b/config/acquia_dev/purge.logger_channels.yml
@@ -15,3 +15,9 @@ channels:
     id: diagnostics
     grants:
       - 3
+  -
+    id: purger_acquia_purge_1816e97490
+    grants:
+      - 0
+      - 2
+      - 3

--- a/config/acquia_dev/purge.plugins.yml
+++ b/config/acquia_dev/purge.plugins.yml
@@ -1,0 +1,4 @@
+purgers:
+  instance_id: '1816e97490'
+  plugin_id: acquia_purge
+  order_index: 2

--- a/config/acquia_prod/purge.logger_channels.yml
+++ b/config/acquia_prod/purge.logger_channels.yml
@@ -15,3 +15,9 @@ channels:
     id: diagnostics
     grants:
       - 3
+  -
+    id: purger_acquia_purge_21b879535d
+    grants:
+      - 0
+      - 2
+      - 3

--- a/config/acquia_prod/purge.plugins.yml
+++ b/config/acquia_prod/purge.plugins.yml
@@ -1,0 +1,4 @@
+purgers:
+  instance_id: '21b879535d'
+  plugin_id: acquia_purge
+  order_index: 2

--- a/config/acquia_stage/purge.logger_channels.yml
+++ b/config/acquia_stage/purge.logger_channels.yml
@@ -16,7 +16,7 @@ channels:
     grants:
       - 3
   -
-    id: purger_acquia_purge_b3b01b1781
+    id: purger_acquia_purge_90d4dd1f41
     grants:
       - 0
       - 2

--- a/config/acquia_stage/purge.plugins.yml
+++ b/config/acquia_stage/purge.plugins.yml
@@ -1,0 +1,4 @@
+purgers:
+  instance_id: '90d4dd1f41'
+  plugin_id: acquia_purge
+  order_index: 2

--- a/config/default/config_split.config_split.acquia_dev.yml
+++ b/config/default/config_split.config_split.acquia_dev.yml
@@ -31,6 +31,9 @@ theme: {  }
 complete_list:
   - bos_theme.settings
   - config_ignore.settings
+  - purge.logger_channels
+  - purge.plugins
+  - purge_queuer_coretags.settings
 partial_list:
   - environment_indicator.indicator
   - metatag.metatag_defaults.global

--- a/config/default/config_split.config_split.acquia_prod.yml
+++ b/config/default/config_split.config_split.acquia_prod.yml
@@ -26,5 +26,8 @@ theme: {  }
 complete_list:
   - bos_theme.settings
   - config_ignore.settings
+  - purge.logger_channels
+  - purge.plugins
+  - purge_queuer_coretags.settings
 partial_list:
   - environment_indicator.indicator

--- a/config/default/config_split.config_split.acquia_stage.yml
+++ b/config/default/config_split.config_split.acquia_stage.yml
@@ -26,6 +26,9 @@ theme: {  }
 complete_list:
   - bos_theme.settings
   - config_ignore.settings
+  - purge.logger_channels
+  - purge.plugins
+  - purge_queuer_coretags.settings
 partial_list:
   - environment_indicator.indicator
   - metatag.metatag_defaults.global

--- a/config/local/config_ignore.settings.yml
+++ b/config/local/config_ignore.settings.yml
@@ -9,7 +9,6 @@ ignored_config_entities:
   - 'core.entity_view_display.node.metrolist_development.*'
   - geolocation_google_maps.settings
   - 'paragraphs.paragraphs_type.*:dependencies.content|icon_uuid'
-  - purge.logger_channels
   - salesforce.salesforce_auth.dnd_prod
   - salesforce.settings
   - slackposter.settings


### PR DESCRIPTION
Adds the purger config to each environment so that when configs are imported the purgers are not removed.