### PR TITLE
(develop) Allows broader telephone number format on metrolist_listing webform

### DIFF
--- a/config/default/webform.webform.metrolist_listing.yml
+++ b/config/default/webform.webform.metrolist_listing.yml
@@ -104,6 +104,8 @@ elements: |-
           '#title': 'Contact Phone'
           '#input_mask': '(999) 999-9999'
           '#required': true
+          '#pattern': '[\(]?[0-9]{3}[\)\-\s]*[0-9]{3}[\s\-]?[0-9]{4}'
+          '#pattern_error': 'US phone number must have 10 digits.'
           '#format_items': comma
       contact_address:
         '#type': webform_address


### PR DESCRIPTION
DIG-433 - Telephone number (&date) format on metrolist_listing webform

**I cannot replicate the date issue atm.**