### PR TITLE
(develop) Fix subdomain redirect in configuration for rentsmart.boston.gov

### DIFF
--- a/config/acquia_prod/redirect_domain.domains.yml
+++ b/config/acquia_prod/redirect_domain.domains.yml
@@ -4,7 +4,7 @@ domain_redirects:
   'rentsmart:boston:gov':
     -
       sub_path: /
-      destination: https://www.boston.gov/rentsmart
+      destination: www.boston.gov/rentsmart
   'budget:boston:gov':
     -
       sub_path: /


### PR DESCRIPTION
DIG-989