### PR TITLE
DIG-993 Contact forms on Boston.gov failing to send - hotfix

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_email/src/Controller/PostmarkAPI.php
+++ b/docroot/modules/custom/bos_components/modules/bos_email/src/Controller/PostmarkAPI.php
@@ -56,7 +56,7 @@ class PostmarkAPI extends ControllerBase {
    */
   public function token(string $operation) {
     $data = $this->request->getCurrentRequest()->get('data');
-    $token = new tokenOps();
+    $token = new TokenOps();
 
     if ($operation == "create") {
       $response_token = $token->tokenCreate();


### PR DESCRIPTION
Production bug-fix, misnamed class.