### PR TITLE
(develop) Contact forms on Boston.gov failing to send - Hotfix

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_email/src/Controller/PostmarkAPI.php
+++ b/docroot/modules/custom/bos_components/modules/bos_email/src/Controller/PostmarkAPI.php
@@ -299,7 +299,7 @@ class PostmarkAPI extends ControllerBase {
    *   The server being called via the endpoint uri.
    */
   public function beginSession(string $server) {
-    $token = new tokenOps();
+    $token = new TokenOps();
     $data = $this->request->getCurrentRequest()->get('email');
     $data_token = $token->tokenGet($data["token_session"]);
 


### PR DESCRIPTION
DIG-993