### PR TITLE
[develop] re-enabled mysql DIG-1206

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -109,6 +109,7 @@ module:
   metatag_twitter_cards: 0
   moderation_sidebar: 0
   module_filter: 0
+  mysql: 0
   node: 0
   office_hours: 0
   options: 0


### PR DESCRIPTION
Previous [develop] deploy has issues.
Seems the database is not functional, so trying to add back the mysql module which some installations have been complaining about missing.