### PR TITLE
Adds Percy test to validate that BH maps are showing. 

### DIFF
--- a/.github/percy/snapshot_config.yml
+++ b/.github/percy/snapshot_config.yml
@@ -96,3 +96,6 @@
 
 - name: Procurement - BFD THERMAL IMAGING CAMERAS ...
   url: https://d8-dev.boston.gov/node/15920521
+
+- name: Map Verification - ROBEY ST (BH)
+  url: https://d8-dev.boston.gov/node/13690116


### PR DESCRIPTION
DIG-1247: A new API key has been added for Google maps.  This update to percy will validate that the key does not get regressed when updates are made.
At some point in the future BH basemaps (currently google maps) will be replaced with Leaflet/ArcGIS basemaps and the key expiry will not longer be an issue.  The test will however still be valid to check that maps are displaying OK.
