### PR TITLE
(develop) Display unofficial results in the same order as the ballot. DIG-1362

### DIFF
--- a/config/default/core.entity_view_display.node.election_report.default.yml
+++ b/config/default/core.entity_view_display.node.election_report.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.field.node.election_report.field_updated_date
     - node.type.election_report
   module:
-    - datetime
     - entity_reference_revisions
     - fences
     - field_group
@@ -23,14 +22,14 @@ third_party_settings:
         - published_at
         - field_source_file
         - field_election_isofficial
-      label: 'Imported report Metadata'
+      label: 'Imported Report Metadata'
       parent_name: ''
       region: content
-      weight: 3
+      weight: 1
       format_type: fieldset
       format_settings:
         classes: ''
-        show_empty_fields: false
+        show_empty_fields: true
         id: ''
         description: ''
 id: node.election_report.default
@@ -47,12 +46,12 @@ content:
     third_party_settings:
       fences:
         fences_field_tag: div
-        fences_field_classes: ''
-        fences_field_item_tag: div
+        fences_field_classes: area-results-all
+        fences_field_item_tag: none
         fences_field_item_classes: ''
-        fences_label_tag: div
+        fences_label_tag: none
         fences_label_classes: ''
-    weight: 4
+    weight: 2
     region: content
   field_election:
     type: entity_reference_entity_view
@@ -82,7 +81,7 @@ content:
         fences_field_classes: ''
         fences_field_item_tag: none
         fences_field_item_classes: ''
-        fences_label_tag: label
+        fences_label_tag: span
         fences_label_classes: ''
     weight: 5
     region: content
@@ -101,25 +100,9 @@ content:
         fences_field_classes: ''
         fences_field_item_tag: none
         fences_field_item_classes: ''
-        fences_label_tag: label
+        fences_label_tag: span
         fences_label_classes: ''
     weight: 4
-    region: content
-  field_updated_date:
-    type: datetime_default
-    label: inline
-    settings:
-      timezone_override: UTC
-      format_type: long
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    weight: 1
     region: content
   published_at:
     type: timestamp
@@ -134,10 +117,11 @@ content:
         fences_field_classes: ''
         fences_field_item_tag: none
         fences_field_item_classes: ''
-        fences_label_tag: label
+        fences_label_tag: span
         fences_label_classes: ''
     weight: 3
     region: content
 hidden:
+  field_updated_date: true
   langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.election_report.election_card.yml
+++ b/config/default/core.entity_view_display.node.election_report.election_card.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.node.election_report.field_updated_date
     - node.type.election_report
   module:
-    - datetime
     - entity_reference_revisions
     - fences
     - user
@@ -28,13 +27,13 @@ content:
       link: ''
     third_party_settings:
       fences:
-        fences_field_tag: none
-        fences_field_classes: ''
+        fences_field_tag: div
+        fences_field_classes: area-results-all
         fences_field_item_tag: none
         fences_field_item_classes: ''
         fences_label_tag: none
         fences_label_classes: ''
-    weight: 3
+    weight: 1
     region: content
   field_election:
     type: entity_reference_label
@@ -51,25 +50,10 @@ content:
         fences_label_classes: ''
     weight: 0
     region: content
-  field_updated_date:
-    type: datetime_default
-    label: inline
-    settings:
-      timezone_override: UTC
-      format_type: long
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    weight: 1
-    region: content
 hidden:
   field_election_isofficial: true
   field_source_file: true
+  field_updated_date: true
   langcode: true
   links: true
   published_at: true

--- a/docroot/modules/custom/bos_content/modules/node_elections/js/node_elections.js
+++ b/docroot/modules/custom/bos_content/modules/node_elections/js/node_elections.js
@@ -1,0 +1,47 @@
+  /**
+   * Unofficial election results
+   * Sort results into preferred order on page.
+   * 11/2022
+   */
+  (function ($, document) {
+    'use strict';
+    function getSorted(selector, attrName) {
+      return $($(selector).toArray().sort(function(a, b){
+        var aVal = parseInt(a.getAttribute(attrName)),
+          bVal = parseInt(b.getAttribute(attrName));
+        return aVal - bVal;
+      }));
+    }
+    jQuery(document).ready(function () {
+      let sorted = getSorted(".cob-election-contest", "data-sort");
+      let results = $(".area-results-all");
+      results.find(".cob-election-contest").remove();
+      results
+        .append(
+          $("<div>")
+            .addClass("b b--fw bg--g000")
+            .attr("bos_context_type", "Election Contest Results")
+            .attr("id", "0")
+        )
+        .append(sorted);
+    });
+  })(jQuery, this.document);
+
+  /**
+   * Unofficial election results
+   * Filter election results based on select option value
+   * 10/19/2022
+   */
+  (function ($) {
+    'use strict';
+    $('#election_results').on('change', function() {
+      var url = $(this).val(); // get selected value
+      let result = $('.cob-election-contest');
+      result.hide().removeClass('bg--g000').removeClass("b--g");
+      $("#"+url).show().addClass('b--g');
+      if (url === "all") {
+        result.show().addClass('bg--g000');
+      }
+      return false;
+    });
+  })(jQuery);

--- a/docroot/modules/custom/bos_content/modules/node_elections/node_elections.libraries.yml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/node_elections.libraries.yml
@@ -2,6 +2,10 @@ election:
   css:
     theme:
       css/node_elections.css: { weight: -10 }
+  js:
+    js/node_elections.js: {attributes: {type: text/javascript}}
+  dependencies:
+    - core/jquery
 
 election_admin:
   css:

--- a/docroot/modules/custom/bos_content/modules/node_elections/node_elections.module
+++ b/docroot/modules/custom/bos_content/modules/node_elections/node_elections.module
@@ -31,6 +31,9 @@ function node_elections_theme($existing, $type, $theme, $path) {
     'paragraph__election_card__full' => [
       'base hook' => 'paragraph',
     ],
+    'taxonomy_term__elections' => [
+      'base hook' => 'taxonomy_term',
+    ],
     'taxonomy_term__election_contests' => [
       'base hook' => 'taxonomy_term',
     ],
@@ -46,6 +49,11 @@ function node_elections_preprocess_node(&$variables, $a) {
       "election_report",
     ])) {
     $variables['#attached']['library'][] = 'node_elections/election';
+    if ($variables["view_mode"] == "full") {
+      $variables['election_title'] = $variables['node']->getTitle();
+      $variables['updated_date'] = date("l, F j, Y - h:iA", $variables['node']->getChangedTime() );
+      _sortedSelectBox($variables, $variables['node']);
+    }
 
   }
 
@@ -67,30 +75,9 @@ function node_elections_preprocess_paragraph(&$variables) {
       $election = \Drupal::entityTypeManager()
         ->getStorage("node")
         ->load($election_id);
-
-      $variables['updated_date'] = date("l, F j, Y - h:iA", $election->changed[0]->value );
-      $variables['election_title'] = $election->title[0]->value;
-
-      $variables["area_option"] = [];
-      foreach ($election->field_area_results as $para) {
-        if ($para_area = \Drupal::entityTypeManager()
-          ->getStorage("paragraph")
-          ->load($para->target_id)) {
-          foreach ($para_area->field_election_contest_results as $para_contest_id) {
-            if ($para_contest = \Drupal::entityTypeManager()
-              ->getStorage("paragraph")
-              ->load($para_contest_id->target_id)) {
-              if ($term_id = $para_contest->field_election_contest[0]->target_id) {
-                $term = \Drupal::entityTypeManager()
-                  ->getStorage("taxonomy_term")
-                  ->load($term_id);
-                $variables["area_option"][$term->field_contest_sortorder->value] = $term->field_display_title->value;
-              }
-            }
-          }
-        }
-      }
-      ksort($variables["area_option"]);
+      $variables['updated_date'] = date("l, F j, Y - h:iA", $election->getChangedTime() );
+      $variables['election_title'] = $election->getTitle();
+      _sortedSelectBox($variables, $election);
     }
   }
 
@@ -368,4 +355,38 @@ function node_elections_form_taxonomy_overview_terms_alter(&$form, FormStateInte
       break;
   }
 
+}
+
+/**
+ * Builds the election contests as options in a selectbox, sorted by preferred
+ * sort order.
+ *
+ * @param array $variables The standard variables render array.
+ * @param \Drupal\node\Entity\Node $election Bundle type "election_report".
+ *
+ * @return void
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function _sortedSelectBox(array &$variables, $election) {
+  $variables["area_option"] = [];
+  foreach ($election->field_area_results as $para) {
+    if ($para_area = \Drupal::entityTypeManager()
+      ->getStorage("paragraph")
+      ->load($para->target_id)) {
+      foreach ($para_area->field_election_contest_results as $para_contest_id) {
+        if ($para_contest = \Drupal::entityTypeManager()
+          ->getStorage("paragraph")
+          ->load($para_contest_id->target_id)) {
+          if ($term_id = $para_contest->field_election_contest[0]->target_id) {
+            $term = \Drupal::entityTypeManager()
+              ->getStorage("taxonomy_term")
+              ->load($term_id);
+            $variables["area_option"][$term->field_contest_sortorder->value] = $term->field_display_title->value;
+          }
+        }
+      }
+    }
+  }
+  ksort($variables["area_option"]);
 }

--- a/docroot/modules/custom/bos_content/modules/node_elections/templates/node--election-report--full.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_elections/templates/node--election-report--full.html.twig
@@ -74,12 +74,28 @@
   <div class="b-c b-c--ntp b-c--nbp m-t600">
     <div class="sh cl">
       <h2 class="sh-title" role="listitem">
-        {{ title["#items"][0]["value"] }}
+        {{ election_title }}
       </h2>
     </div>
-    <p class="t--regular"><strong>Last Updated:</strong> {{ content.field_updated_date }}</p>
-    {# We hide the comments and links now so that we can render them later. #}
-    {{ content|without('links','comments','field_election','field_updated_date') }}
+
+    <p class="t--regular"><strong>Result Generation Timestamp:</strong> {{ updated_date }}</p>
+
+    {{ content.field_election }}
+    {{ content.group_fileset }}
+
+    <div class="sel m-t000 m-b300">
+      <label for="language" class="sel-l m-t000">Choose a result to display</label>
+      <div class="sel-c">
+        <select name="election_results" id="election_results" class="sel-f election_results_select">
+          <option value="all">View all results</option>
+          {% for key, value in area_option %}
+            <option value="{{ key }}">{{ value }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
+    {{ content.field_area_results }}
 
     {{ content['links']  }}
     {{ content['comments']  }}

--- a/docroot/modules/custom/bos_content/modules/node_elections/templates/paragraph--election-area-results--election-card.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_elections/templates/paragraph--election-area-results--election-card.html.twig
@@ -23,10 +23,4 @@
  * @see template_preprocess_entity()
  * @see template_process()
  #}
-<div class="b b--fw bg--g000"{{ attributes }}>
-  <div class="election_results_parent">
-    <div class="g">
-      {{ content }}
-    </div>
-  </div>
-</div>
+  {{ content|without("contextual_links") }}

--- a/docroot/modules/custom/bos_content/modules/node_elections/templates/paragraph--election-card--full.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_elections/templates/paragraph--election-card--full.html.twig
@@ -23,7 +23,7 @@
  * @see template_preprocess_entity()
  * @see template_process()
  #}
-<div class="b b--fw" {{ attributes }}>
+<div class="b b--fw m-t600" {{ attributes }}>
   <div class="b-c b-c--ntp b-c--nbp">
     <div class="sh cl">
       <h2 class="sh-title" role="listitem">
@@ -48,7 +48,6 @@
     <div class="g">
       <div class="g--12">
         {{ content|without('field_election_disclaimer') }}
-        <div class="p-b600"></div>
       </div>
     </div>
   </div>

--- a/docroot/modules/custom/bos_content/modules/node_elections/templates/paragraph--election-contest-results--election-card.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_elections/templates/paragraph--election-contest-results--election-card.html.twig
@@ -23,8 +23,7 @@
  * @see template_preprocess_entity()
  * @see template_process()
  #}
-<div class="b b--fw es_hide"{{ attributes }} id="{{ sortorder }}">
-
+<div class="b b--fw bg--g000 cob-election-contest"{{ attributes }} id="{{ sortorder }}" data-sort="{{ sortorder }}">
   <div class="b-c b-c--ntp p-t700">
     <div class="g">
       <div class="g--12 election_contest_title p-t600"> {{ content.field_election_contest }} </div>

--- a/docroot/modules/custom/bos_content/modules/node_elections/templates/taxonomy-term--elections.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_elections/templates/taxonomy-term--elections.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Theme override to display a taxonomy term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+<div{{ attributes }}>
+  {{ content }}
+</div>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T17_52_57.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T17_52_57.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 17:52:57" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 17:52:57</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="0" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="0" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="0" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="0" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats />
+   <results />
+   <pollprogress>
+      <area areaId="1" reported="0" total="275" />
+      <area areaId="2" reported="0" total="275" />
+      <area areaId="3" reported="0" total="189" />
+      <area areaId="4" reported="0" total="86" />
+      <area areaId="5" reported="0" total="35" />
+      <area areaId="6" reported="0" total="195" />
+      <area areaId="7" reported="0" total="45" />
+      <area areaId="8" reported="0" total="83" />
+      <area areaId="9" reported="0" total="73" />
+      <area areaId="10" reported="0" total="37" />
+      <area areaId="11" reported="0" total="8" />
+      <area areaId="12" reported="0" total="39" />
+      <area areaId="13" reported="0" total="35" />
+      <area areaId="14" reported="0" total="14" />
+      <area areaId="15" reported="0" total="11" />
+      <area areaId="16" reported="0" total="16" />
+      <area areaId="17" reported="0" total="20" />
+      <area areaId="18" reported="0" total="19" />
+      <area areaId="19" reported="0" total="20" />
+      <area areaId="20" reported="0" total="17" />
+      <area areaId="21" reported="0" total="18" />
+      <area areaId="22" reported="0" total="17" />
+      <area areaId="23" reported="0" total="22" />
+      <area areaId="24" reported="0" total="16" />
+      <area areaId="25" reported="0" total="19" />
+      <area areaId="26" reported="0" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="0" total="15" />
+      <area areaId="29" reported="0" total="13" />
+      <area areaId="30" reported="0" total="275" />
+      <area areaId="31" reported="0" total="275" />
+      <area areaId="32" reported="0" total="275" />
+      <area areaId="33" reported="0" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 21:19:26" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 21:19:26</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="1" ballots="6905" overvotes="2" undervotes="103" numVoters="6802" pushContests="0" />
+      <contest contestId="5" ballots="6905" overvotes="1" undervotes="187" numVoters="6718" pushContests="0" />
+      <contest contestId="7" ballots="6905" overvotes="0" undervotes="211" numVoters="6694" pushContests="0" />
+      <contest contestId="9" ballots="6905" overvotes="0" undervotes="635" numVoters="6270" pushContests="0" />
+      <contest contestId="11" ballots="6905" overvotes="3" undervotes="445" numVoters="6460" pushContests="0" />
+      <contest contestId="13" ballots="3651" overvotes="0" undervotes="221" numVoters="3430" pushContests="0" />
+      <contest contestId="15" ballots="3254" overvotes="1" undervotes="211" numVoters="3043" pushContests="0" />
+      <contest contestId="17" ballots="1533" overvotes="0" undervotes="285" numVoters="1248" pushContests="0" />
+      <contest contestId="19" ballots="3482" overvotes="1" undervotes="294" numVoters="3188" pushContests="0" />
+      <contest contestId="21" ballots="1890" overvotes="0" undervotes="422" numVoters="1468" pushContests="0" />
+      <contest contestId="23" ballots="2887" overvotes="1" undervotes="557" numVoters="2330" pushContests="0" />
+      <contest contestId="25" ballots="1533" overvotes="0" undervotes="279" numVoters="1254" pushContests="0" />
+      <contest contestId="27" ballots="603" overvotes="0" undervotes="116" numVoters="487" pushContests="0" />
+      <contest contestId="31" ballots="595" overvotes="0" undervotes="64" numVoters="531" pushContests="0" />
+      <contest contestId="33" ballots="1287" overvotes="1" undervotes="279" numVoters="1008" pushContests="0" />
+      <contest contestId="35" ballots="407" overvotes="0" undervotes="117" numVoters="290" pushContests="0" />
+      <contest contestId="37" ballots="603" overvotes="0" undervotes="107" numVoters="496" pushContests="0" />
+      <contest contestId="39" ballots="880" overvotes="0" undervotes="157" numVoters="723" pushContests="0" />
+      <contest contestId="41" ballots="1516" overvotes="0" undervotes="330" numVoters="1186" pushContests="0" />
+      <contest contestId="47" ballots="595" overvotes="0" undervotes="74" numVoters="521" pushContests="0" />
+      <contest contestId="51" ballots="950" overvotes="0" undervotes="173" numVoters="777" pushContests="0" />
+      <contest contestId="57" ballots="421" overvotes="0" undervotes="100" numVoters="321" pushContests="0" />
+      <contest contestId="63" ballots="556" overvotes="0" undervotes="88" numVoters="468" pushContests="0" />
+      <contest contestId="65" ballots="977" overvotes="0" undervotes="189" numVoters="788" pushContests="0" />
+      <contest contestId="67" ballots="6905" overvotes="0" undervotes="1487" numVoters="5418" pushContests="0" />
+      <contest contestId="69" ballots="6905" overvotes="0" undervotes="1527" numVoters="5378" pushContests="0" />
+      <contest contestId="70" ballots="6905" overvotes="4" undervotes="269" numVoters="6636" pushContests="0" />
+      <contest contestId="71" ballots="6905" overvotes="2" undervotes="396" numVoters="6509" pushContests="0" />
+      <contest contestId="72" ballots="6873" overvotes="2" undervotes="276" numVoters="6597" pushContests="0" />
+      <contest contestId="73" ballots="6873" overvotes="1" undervotes="459" numVoters="6414" pushContests="0" />
+      <contest contestId="74" ballots="419" overvotes="0" undervotes="66" numVoters="353" pushContests="0" />
+      <contest contestId="75" ballots="419" overvotes="0" undervotes="96" numVoters="323" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="1413" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="5247" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="125" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="15" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="5167" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="1536" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="14" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="5318" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="273" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="1093" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="10" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="5312" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="931" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="27" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="233" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="4342" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="1592" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="164" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="116" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="10" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="2820" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="598" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="12" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="2392" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="638" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="12" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="1230" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="18" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="2501" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="675" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="11" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="1442" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="26" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="2272" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="57" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="1239" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="15" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="482" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="5" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="522" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="9" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="987" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="20" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="285" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="5" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="490" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="6" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="715" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="8" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="1152" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="34" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="515" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="6" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="765" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="12" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="311" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="10" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="462" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="6" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="775" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="13" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="5295" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="123" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="5275" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="103" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="4117" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="2515" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="5102" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="1405" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="3646" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="2949" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="4425" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="1988" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="238" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="115" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="260" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="63" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="13" total="275" />
+      <area areaId="2" reported="13" total="275" />
+      <area areaId="3" reported="7" total="189" />
+      <area areaId="4" reported="6" total="86" />
+      <area areaId="5" reported="3" total="35" />
+      <area areaId="6" reported="7" total="195" />
+      <area areaId="7" reported="3" total="45" />
+      <area areaId="8" reported="6" total="83" />
+      <area areaId="9" reported="1" total="73" />
+      <area areaId="10" reported="2" total="37" />
+      <area areaId="11" reported="1" total="8" />
+      <area areaId="12" reported="0" total="39" />
+      <area areaId="13" reported="3" total="35" />
+      <area areaId="14" reported="1" total="14" />
+      <area areaId="15" reported="1" total="11" />
+      <area areaId="16" reported="1" total="16" />
+      <area areaId="17" reported="3" total="20" />
+      <area areaId="18" reported="0" total="19" />
+      <area areaId="19" reported="0" total="20" />
+      <area areaId="20" reported="1" total="17" />
+      <area areaId="21" reported="0" total="18" />
+      <area areaId="22" reported="2" total="17" />
+      <area areaId="23" reported="0" total="22" />
+      <area areaId="24" reported="0" total="16" />
+      <area areaId="25" reported="1" total="19" />
+      <area areaId="26" reported="0" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="1" total="15" />
+      <area areaId="29" reported="2" total="13" />
+      <area areaId="30" reported="13" total="275" />
+      <area areaId="31" reported="13" total="275" />
+      <area areaId="32" reported="13" total="275" />
+      <area areaId="33" reported="1" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_0.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_0.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 21:24:23" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 21:24:23</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="5218" overvotes="1" undervotes="1112" numVoters="4106" pushContests="0" />
+      <contest contestId="69" ballots="10937" overvotes="0" undervotes="2406" numVoters="8531" pushContests="0" />
+      <contest contestId="75" ballots="419" overvotes="0" undervotes="96" numVoters="323" pushContests="0" />
+      <contest contestId="9" ballots="10937" overvotes="0" undervotes="1056" numVoters="9881" pushContests="0" />
+      <contest contestId="15" ballots="3771" overvotes="1" undervotes="237" numVoters="3534" pushContests="0" />
+      <contest contestId="72" ballots="10872" overvotes="3" undervotes="558" numVoters="10314" pushContests="0" />
+      <contest contestId="35" ballots="407" overvotes="0" undervotes="117" numVoters="290" pushContests="0" />
+      <contest contestId="63" ballots="1065" overvotes="0" undervotes="159" numVoters="906" pushContests="0" />
+      <contest contestId="49" ballots="514" overvotes="0" undervotes="91" numVoters="423" pushContests="0" />
+      <contest contestId="67" ballots="10937" overvotes="0" undervotes="2350" numVoters="8587" pushContests="0" />
+      <contest contestId="21" ballots="2921" overvotes="0" undervotes="652" numVoters="2269" pushContests="0" />
+      <contest contestId="27" ballots="603" overvotes="0" undervotes="116" numVoters="487" pushContests="0" />
+      <contest contestId="7" ballots="10937" overvotes="1" undervotes="449" numVoters="10488" pushContests="0" />
+      <contest contestId="1" ballots="10937" overvotes="2" undervotes="146" numVoters="10791" pushContests="0" />
+      <contest contestId="47" ballots="595" overvotes="0" undervotes="74" numVoters="521" pushContests="0" />
+      <contest contestId="70" ballots="10937" overvotes="4" undervotes="433" numVoters="10504" pushContests="0" />
+      <contest contestId="41" ballots="1516" overvotes="0" undervotes="330" numVoters="1186" pushContests="0" />
+      <contest contestId="65" ballots="1138" overvotes="0" undervotes="204" numVoters="934" pushContests="0" />
+      <contest contestId="19" ballots="5813" overvotes="1" undervotes="605" numVoters="5208" pushContests="0" />
+      <contest contestId="73" ballots="10872" overvotes="1" undervotes="799" numVoters="10073" pushContests="0" />
+      <contest contestId="25" ballots="2203" overvotes="0" undervotes="372" numVoters="1831" pushContests="0" />
+      <contest contestId="13" ballots="7166" overvotes="1" undervotes="525" numVoters="6641" pushContests="0" />
+      <contest contestId="5" ballots="10937" overvotes="1" undervotes="336" numVoters="10601" pushContests="0" />
+      <contest contestId="33" ballots="2318" overvotes="1" undervotes="501" numVoters="1817" pushContests="0" />
+      <contest contestId="39" ballots="2966" overvotes="0" undervotes="655" numVoters="2311" pushContests="0" />
+      <contest contestId="71" ballots="10937" overvotes="3" undervotes="783" numVoters="10154" pushContests="0" />
+      <contest contestId="17" ballots="2203" overvotes="0" undervotes="384" numVoters="1819" pushContests="0" />
+      <contest contestId="31" ballots="595" overvotes="0" undervotes="64" numVoters="531" pushContests="0" />
+      <contest contestId="11" ballots="10937" overvotes="4" undervotes="838" numVoters="10099" pushContests="0" />
+      <contest contestId="74" ballots="419" overvotes="0" undervotes="66" numVoters="353" pushContests="0" />
+      <contest contestId="57" ballots="421" overvotes="0" undervotes="100" numVoters="321" pushContests="0" />
+      <contest contestId="37" ballots="603" overvotes="0" undervotes="107" numVoters="496" pushContests="0" />
+      <contest contestId="51" ballots="1712" overvotes="0" undervotes="268" numVoters="1444" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="1929" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="8642" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="192" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="26" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="8456" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="2122" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="22" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="8492" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="436" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="1541" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="18" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="8489" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="1348" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="44" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="365" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="6946" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="2352" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="235" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="182" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="15" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="5581" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="1026" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="33" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="2773" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="745" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="15" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="1786" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="33" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="4235" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="955" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="17" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="2220" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="49" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="4013" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="92" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="1801" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="30" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="482" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="5" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="522" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="9" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="1772" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="44" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="285" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="5" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="490" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="6" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="2266" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="45" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="1152" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="34" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="515" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="6" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="413" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="10" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="1421" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="23" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="311" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="10" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="892" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="14" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="918" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="16" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="8386" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="201" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="8357" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="174" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="6629" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="3871" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="8106" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="2045" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="5884" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="4427" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="7286" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="2786" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="238" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="115" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="260" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="63" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="20" total="275" />
+      <area areaId="2" reported="20" total="275" />
+      <area areaId="3" reported="13" total="189" />
+      <area areaId="4" reported="7" total="86" />
+      <area areaId="5" reported="5" total="35" />
+      <area areaId="6" reported="10" total="195" />
+      <area areaId="7" reported="5" total="45" />
+      <area areaId="8" reported="9" total="83" />
+      <area areaId="9" reported="1" total="73" />
+      <area areaId="10" reported="4" total="37" />
+      <area areaId="11" reported="1" total="8" />
+      <area areaId="12" reported="0" total="39" />
+      <area areaId="13" reported="5" total="35" />
+      <area areaId="14" reported="1" total="14" />
+      <area areaId="15" reported="1" total="11" />
+      <area areaId="16" reported="4" total="16" />
+      <area areaId="17" reported="3" total="20" />
+      <area areaId="18" reported="0" total="19" />
+      <area areaId="19" reported="0" total="20" />
+      <area areaId="20" reported="1" total="17" />
+      <area areaId="21" reported="1" total="18" />
+      <area areaId="22" reported="3" total="17" />
+      <area areaId="23" reported="0" total="22" />
+      <area areaId="24" reported="0" total="16" />
+      <area areaId="25" reported="1" total="19" />
+      <area areaId="26" reported="0" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="2" total="15" />
+      <area areaId="29" reported="3" total="13" />
+      <area areaId="30" reported="20" total="275" />
+      <area areaId="31" reported="20" total="275" />
+      <area areaId="32" reported="20" total="275" />
+      <area areaId="33" reported="1" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_1.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_1.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 21:41:19" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 21:41:19</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="10282" overvotes="1" undervotes="2190" numVoters="8092" pushContests="0" />
+      <contest contestId="69" ballots="21595" overvotes="2" undervotes="4943" numVoters="16652" pushContests="0" />
+      <contest contestId="75" ballots="2845" overvotes="0" undervotes="723" numVoters="2122" pushContests="0" />
+      <contest contestId="9" ballots="21595" overvotes="4" undervotes="2272" numVoters="19323" pushContests="0" />
+      <contest contestId="15" ballots="8350" overvotes="2" undervotes="518" numVoters="7832" pushContests="0" />
+      <contest contestId="72" ballots="21491" overvotes="8" undervotes="1165" numVoters="20326" pushContests="0" />
+      <contest contestId="35" ballots="2895" overvotes="0" undervotes="574" numVoters="2321" pushContests="0" />
+      <contest contestId="63" ballots="1065" overvotes="0" undervotes="159" numVoters="906" pushContests="0" />
+      <contest contestId="43" ballots="322" overvotes="0" undervotes="66" numVoters="256" pushContests="0" />
+      <contest contestId="55" ballots="471" overvotes="0" undervotes="129" numVoters="342" pushContests="0" />
+      <contest contestId="49" ballots="1066" overvotes="0" undervotes="153" numVoters="913" pushContests="0" />
+      <contest contestId="67" ballots="21595" overvotes="4" undervotes="4729" numVoters="16866" pushContests="0" />
+      <contest contestId="21" ballots="5961" overvotes="1" undervotes="1322" numVoters="4639" pushContests="0" />
+      <contest contestId="27" ballots="603" overvotes="0" undervotes="116" numVoters="487" pushContests="0" />
+      <contest contestId="7" ballots="21595" overvotes="5" undervotes="810" numVoters="20785" pushContests="0" />
+      <contest contestId="1" ballots="21595" overvotes="5" undervotes="272" numVoters="21323" pushContests="0" />
+      <contest contestId="47" ballots="1159" overvotes="2" undervotes="165" numVoters="994" pushContests="0" />
+      <contest contestId="70" ballots="21595" overvotes="9" undervotes="1033" numVoters="20562" pushContests="0" />
+      <contest contestId="41" ballots="3204" overvotes="0" undervotes="705" numVoters="2499" pushContests="0" />
+      <contest contestId="65" ballots="2038" overvotes="0" undervotes="434" numVoters="1604" pushContests="0" />
+      <contest contestId="19" ballots="12531" overvotes="4" undervotes="1221" numVoters="11310" pushContests="0" />
+      <contest contestId="73" ballots="21491" overvotes="5" undervotes="1591" numVoters="19900" pushContests="0" />
+      <contest contestId="25" ballots="3103" overvotes="0" undervotes="594" numVoters="2509" pushContests="0" />
+      <contest contestId="13" ballots="13245" overvotes="4" undervotes="927" numVoters="12318" pushContests="0" />
+      <contest contestId="5" ballots="21595" overvotes="4" undervotes="625" numVoters="20970" pushContests="0" />
+      <contest contestId="33" ballots="5358" overvotes="1" undervotes="1061" numVoters="4297" pushContests="0" />
+      <contest contestId="39" ballots="2966" overvotes="0" undervotes="655" numVoters="2311" pushContests="0" />
+      <contest contestId="45" ballots="1090" overvotes="0" undervotes="152" numVoters="938" pushContests="0" />
+      <contest contestId="71" ballots="21595" overvotes="4" undervotes="1659" numVoters="19936" pushContests="0" />
+      <contest contestId="17" ballots="3103" overvotes="0" undervotes="622" numVoters="2481" pushContests="0" />
+      <contest contestId="31" ballots="2249" overvotes="2" undervotes="282" numVoters="1967" pushContests="0" />
+      <contest contestId="11" ballots="21595" overvotes="8" undervotes="1584" numVoters="20011" pushContests="0" />
+      <contest contestId="74" ballots="2845" overvotes="0" undervotes="603" numVoters="2242" pushContests="0" />
+      <contest contestId="57" ballots="2385" overvotes="0" undervotes="593" numVoters="1792" pushContests="0" />
+      <contest contestId="37" ballots="603" overvotes="0" undervotes="107" numVoters="496" pushContests="0" />
+      <contest contestId="51" ballots="2331" overvotes="0" undervotes="395" numVoters="1936" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="4563" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="16354" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="358" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="43" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="16105" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="4817" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="44" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="16291" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="860" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="3581" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="48" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="16317" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="2890" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="112" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="714" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="13359" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="5025" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="495" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="373" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="37" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="10095" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="2169" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="50" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="6108" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="1696" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="26" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="2428" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="53" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="8881" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="2388" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="37" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="4513" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="125" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="7887" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="204" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="2464" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="45" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="482" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="5" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="1933" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="32" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="4164" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="132" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="2261" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="60" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="490" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="6" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="2266" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="45" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="2431" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="68" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="46" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="207" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="3" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="927" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="11" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="977" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="15" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="898" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="15" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="1897" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="39" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="335" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="7" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="1731" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="61" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="892" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="14" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="1573" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="31" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="16407" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="455" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="16256" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="394" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="12746" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="7807" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="15568" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="4364" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="10954" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="9364" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="13550" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="6345" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="1424" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="818" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="1611" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="511" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="40" total="275" />
+      <area areaId="2" reported="40" total="275" />
+      <area areaId="3" reported="26" total="189" />
+      <area areaId="4" reported="14" total="86" />
+      <area areaId="5" reported="6" total="35" />
+      <area areaId="6" reported="24" total="195" />
+      <area areaId="7" reported="10" total="45" />
+      <area areaId="8" reported="18" total="83" />
+      <area areaId="9" reported="6" total="73" />
+      <area areaId="10" reported="9" total="37" />
+      <area areaId="11" reported="1" total="8" />
+      <area areaId="12" reported="0" total="39" />
+      <area areaId="13" reported="6" total="35" />
+      <area areaId="14" reported="5" total="14" />
+      <area areaId="15" reported="1" total="11" />
+      <area areaId="16" reported="4" total="16" />
+      <area areaId="17" reported="5" total="20" />
+      <area areaId="18" reported="1" total="19" />
+      <area areaId="19" reported="3" total="20" />
+      <area areaId="20" reported="3" total="17" />
+      <area areaId="21" reported="2" total="18" />
+      <area areaId="22" reported="4" total="17" />
+      <area areaId="23" reported="0" total="22" />
+      <area areaId="24" reported="1" total="16" />
+      <area areaId="25" reported="5" total="19" />
+      <area areaId="26" reported="0" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="2" total="15" />
+      <area areaId="29" reported="4" total="13" />
+      <area areaId="30" reported="40" total="275" />
+      <area areaId="31" reported="40" total="275" />
+      <area areaId="32" reported="40" total="275" />
+      <area areaId="33" reported="6" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_2.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_2.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 21:49:40" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 21:49:40</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="14815" overvotes="2" undervotes="3069" numVoters="11746" pushContests="0" />
+      <contest contestId="69" ballots="32880" overvotes="3" undervotes="7776" numVoters="25104" pushContests="0" />
+      <contest contestId="29" ballots="723" overvotes="0" undervotes="172" numVoters="551" pushContests="0" />
+      <contest contestId="75" ballots="3718" overvotes="0" undervotes="929" numVoters="2789" pushContests="0" />
+      <contest contestId="9" ballots="32880" overvotes="5" undervotes="3377" numVoters="29503" pushContests="0" />
+      <contest contestId="15" ballots="14564" overvotes="2" undervotes="1009" numVoters="13555" pushContests="0" />
+      <contest contestId="72" ballots="32702" overvotes="14" undervotes="1749" numVoters="30953" pushContests="0" />
+      <contest contestId="35" ballots="2895" overvotes="0" undervotes="574" numVoters="2321" pushContests="0" />
+      <contest contestId="63" ballots="1065" overvotes="0" undervotes="159" numVoters="906" pushContests="0" />
+      <contest contestId="55" ballots="1350" overvotes="0" undervotes="280" numVoters="1070" pushContests="0" />
+      <contest contestId="43" ballots="322" overvotes="0" undervotes="66" numVoters="256" pushContests="0" />
+      <contest contestId="49" ballots="3747" overvotes="0" undervotes="730" numVoters="3017" pushContests="0" />
+      <contest contestId="67" ballots="32880" overvotes="5" undervotes="7526" numVoters="25354" pushContests="0" />
+      <contest contestId="21" ballots="11990" overvotes="2" undervotes="2912" numVoters="9078" pushContests="0" />
+      <contest contestId="27" ballots="1517" overvotes="1" undervotes="304" numVoters="1213" pushContests="0" />
+      <contest contestId="7" ballots="32880" overvotes="9" undervotes="1244" numVoters="31636" pushContests="0" />
+      <contest contestId="1" ballots="32880" overvotes="8" undervotes="393" numVoters="32487" pushContests="0" />
+      <contest contestId="47" ballots="1159" overvotes="2" undervotes="165" numVoters="994" pushContests="0" />
+      <contest contestId="70" ballots="32880" overvotes="12" undervotes="1369" numVoters="31511" pushContests="0" />
+      <contest contestId="41" ballots="5179" overvotes="0" undervotes="1165" numVoters="4014" pushContests="0" />
+      <contest contestId="65" ballots="2038" overvotes="0" undervotes="434" numVoters="1604" pushContests="0" />
+      <contest contestId="19" ballots="17787" overvotes="4" undervotes="1652" numVoters="16135" pushContests="0" />
+      <contest contestId="73" ballots="32702" overvotes="12" undervotes="2420" numVoters="30282" pushContests="0" />
+      <contest contestId="25" ballots="3103" overvotes="0" undervotes="594" numVoters="2509" pushContests="0" />
+      <contest contestId="13" ballots="18316" overvotes="5" undervotes="1282" numVoters="17034" pushContests="0" />
+      <contest contestId="5" ballots="32880" overvotes="5" undervotes="913" numVoters="31967" pushContests="0" />
+      <contest contestId="33" ballots="10473" overvotes="1" undervotes="2379" numVoters="8094" pushContests="0" />
+      <contest contestId="39" ballots="6002" overvotes="0" undervotes="1447" numVoters="4555" pushContests="0" />
+      <contest contestId="53" ballots="723" overvotes="0" undervotes="177" numVoters="546" pushContests="0" />
+      <contest contestId="45" ballots="1090" overvotes="0" undervotes="152" numVoters="938" pushContests="0" />
+      <contest contestId="71" ballots="32880" overvotes="9" undervotes="2405" numVoters="30475" pushContests="0" />
+      <contest contestId="17" ballots="3103" overvotes="0" undervotes="622" numVoters="2481" pushContests="0" />
+      <contest contestId="31" ballots="2249" overvotes="2" undervotes="282" numVoters="1967" pushContests="0" />
+      <contest contestId="11" ballots="32880" overvotes="11" undervotes="2492" numVoters="30388" pushContests="0" />
+      <contest contestId="74" ballots="3718" overvotes="0" undervotes="762" numVoters="2956" pushContests="0" />
+      <contest contestId="57" ballots="2385" overvotes="0" undervotes="593" numVoters="1792" pushContests="0" />
+      <contest contestId="37" ballots="1517" overvotes="0" undervotes="271" numVoters="1246" pushContests="0" />
+      <contest contestId="51" ballots="3408" overvotes="0" undervotes="544" numVoters="2864" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="6872" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="25022" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="513" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="72" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="24531" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="7374" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="57" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="24898" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="1139" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="5529" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="61" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="24848" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="4501" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="149" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="962" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="20017" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="8151" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="627" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="565" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="55" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="13876" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="3082" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="71" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="10458" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="3059" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="36" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="2428" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="53" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="12681" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="3403" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="47" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="8855" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="221" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="11472" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="272" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="2464" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="45" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="1197" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="15" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="534" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="17" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="1933" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="32" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="7888" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="205" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="2261" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="60" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="1230" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="16" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="4472" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="83" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="3913" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="101" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="46" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="207" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="3" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="927" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="11" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="977" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="15" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="2966" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="51" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="2810" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="54" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="534" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="12" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="1053" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="17" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="1731" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="61" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="892" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="14" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="1573" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="31" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="24707" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="642" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="24552" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="549" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="18356" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="13143" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="23680" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="6786" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="16898" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="14041" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="20634" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="9636" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="1991" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="965" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="2166" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="623" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="53" total="275" />
+      <area areaId="2" reported="53" total="275" />
+      <area areaId="3" reported="32" total="189" />
+      <area areaId="4" reported="21" total="86" />
+      <area areaId="5" reported="6" total="35" />
+      <area areaId="6" reported="30" total="195" />
+      <area areaId="7" reported="17" total="45" />
+      <area areaId="8" reported="23" total="83" />
+      <area areaId="9" reported="6" total="73" />
+      <area areaId="10" reported="15" total="37" />
+      <area areaId="11" reported="2" total="8" />
+      <area areaId="12" reported="1" total="39" />
+      <area areaId="13" reported="6" total="35" />
+      <area areaId="14" reported="5" total="14" />
+      <area areaId="15" reported="2" total="11" />
+      <area areaId="16" reported="8" total="16" />
+      <area areaId="17" reported="7" total="20" />
+      <area areaId="18" reported="1" total="19" />
+      <area areaId="19" reported="3" total="20" />
+      <area areaId="20" reported="3" total="17" />
+      <area areaId="21" reported="5" total="18" />
+      <area areaId="22" reported="5" total="17" />
+      <area areaId="23" reported="1" total="22" />
+      <area areaId="24" reported="2" total="16" />
+      <area areaId="25" reported="5" total="19" />
+      <area areaId="26" reported="0" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="2" total="15" />
+      <area areaId="29" reported="4" total="13" />
+      <area areaId="30" reported="53" total="275" />
+      <area areaId="31" reported="53" total="275" />
+      <area areaId="32" reported="53" total="275" />
+      <area areaId="33" reported="7" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_3.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_3.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 21:54:56" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 21:54:56</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="17279" overvotes="2" undervotes="3544" numVoters="13735" pushContests="0" />
+      <contest contestId="69" ballots="40945" overvotes="3" undervotes="9563" numVoters="31382" pushContests="0" />
+      <contest contestId="29" ballots="2080" overvotes="0" undervotes="443" numVoters="1637" pushContests="0" />
+      <contest contestId="75" ballots="4688" overvotes="0" undervotes="1191" numVoters="3497" pushContests="0" />
+      <contest contestId="9" ballots="40945" overvotes="5" undervotes="4121" numVoters="36824" pushContests="0" />
+      <contest contestId="15" ballots="19099" overvotes="2" undervotes="1309" numVoters="17790" pushContests="0" />
+      <contest contestId="72" ballots="40709" overvotes="18" undervotes="2066" numVoters="38643" pushContests="0" />
+      <contest contestId="35" ballots="3364" overvotes="0" undervotes="642" numVoters="2722" pushContests="0" />
+      <contest contestId="63" ballots="1065" overvotes="0" undervotes="159" numVoters="906" pushContests="0" />
+      <contest contestId="55" ballots="2009" overvotes="0" undervotes="422" numVoters="1587" pushContests="0" />
+      <contest contestId="43" ballots="1035" overvotes="0" undervotes="128" numVoters="907" pushContests="0" />
+      <contest contestId="49" ballots="5311" overvotes="0" undervotes="1034" numVoters="4277" pushContests="0" />
+      <contest contestId="67" ballots="40945" overvotes="5" undervotes="9266" numVoters="31679" pushContests="0" />
+      <contest contestId="21" ballots="13990" overvotes="3" undervotes="3335" numVoters="10655" pushContests="0" />
+      <contest contestId="27" ballots="1517" overvotes="1" undervotes="304" numVoters="1213" pushContests="0" />
+      <contest contestId="7" ballots="40945" overvotes="10" undervotes="1507" numVoters="39438" pushContests="0" />
+      <contest contestId="1" ballots="40945" overvotes="11" undervotes="481" numVoters="40464" pushContests="0" />
+      <contest contestId="47" ballots="1427" overvotes="2" undervotes="217" numVoters="1210" pushContests="0" />
+      <contest contestId="70" ballots="40945" overvotes="15" undervotes="1734" numVoters="39211" pushContests="0" />
+      <contest contestId="41" ballots="6665" overvotes="0" undervotes="1449" numVoters="5216" pushContests="0" />
+      <contest contestId="65" ballots="2607" overvotes="0" undervotes="557" numVoters="2050" pushContests="0" />
+      <contest contestId="19" ballots="23283" overvotes="5" undervotes="2135" numVoters="21148" pushContests="0" />
+      <contest contestId="73" ballots="40709" overvotes="14" undervotes="2954" numVoters="37755" pushContests="0" />
+      <contest contestId="25" ballots="3672" overvotes="0" undervotes="719" numVoters="2953" pushContests="0" />
+      <contest contestId="13" ballots="21846" overvotes="6" undervotes="1517" numVoters="20329" pushContests="0" />
+      <contest contestId="5" ballots="40945" overvotes="7" undervotes="1132" numVoters="39813" pushContests="0" />
+      <contest contestId="33" ballots="12473" overvotes="1" undervotes="2752" numVoters="9721" pushContests="0" />
+      <contest contestId="39" ballots="6002" overvotes="0" undervotes="1447" numVoters="4555" pushContests="0" />
+      <contest contestId="53" ballots="2080" overvotes="0" undervotes="463" numVoters="1617" pushContests="0" />
+      <contest contestId="45" ballots="1090" overvotes="0" undervotes="152" numVoters="938" pushContests="0" />
+      <contest contestId="71" ballots="40945" overvotes="9" undervotes="2873" numVoters="38072" pushContests="0" />
+      <contest contestId="17" ballots="3672" overvotes="0" undervotes="765" numVoters="2907" pushContests="0" />
+      <contest contestId="31" ballots="3924" overvotes="2" undervotes="489" numVoters="3435" pushContests="0" />
+      <contest contestId="11" ballots="40945" overvotes="12" undervotes="3043" numVoters="37902" pushContests="0" />
+      <contest contestId="74" ballots="4688" overvotes="0" undervotes="980" numVoters="3708" pushContests="0" />
+      <contest contestId="57" ballots="2704" overvotes="0" undervotes="666" numVoters="2038" pushContests="0" />
+      <contest contestId="37" ballots="1517" overvotes="0" undervotes="271" numVoters="1246" pushContests="0" />
+      <contest contestId="51" ballots="4069" overvotes="0" undervotes="641" numVoters="3428" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="8435" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="31290" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="630" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="98" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="30725" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="9008" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="73" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="31171" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="1457" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="6719" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="81" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="31113" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="5508" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="198" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="1215" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="25148" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="9970" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="814" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="677" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="66" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="16644" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="3601" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="78" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="13894" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="3839" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="55" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="2845" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="62" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="16758" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="4327" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="58" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="10398" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="254" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="13406" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="327" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="2898" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="55" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="1197" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="15" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="1607" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="30" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="3375" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="58" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="9478" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="242" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="2647" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="75" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="1230" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="16" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="4472" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="83" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="5085" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="131" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="142" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="759" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="6" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="927" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="11" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="1190" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="18" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="4203" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="74" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="3369" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="59" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="1591" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="26" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="1564" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="23" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="1969" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="69" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="892" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="14" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="2012" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="38" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="30866" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="808" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="30701" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="678" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="23214" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="15982" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="29657" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="8406" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="21052" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="17573" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="25733" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="12008" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="2584" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="1124" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="2735" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="762" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="69" total="275" />
+      <area areaId="2" reported="69" total="275" />
+      <area areaId="3" reported="41" total="189" />
+      <area areaId="4" reported="28" total="86" />
+      <area areaId="5" reported="7" total="35" />
+      <area areaId="6" reported="41" total="195" />
+      <area areaId="7" reported="21" total="45" />
+      <area areaId="8" reported="27" total="83" />
+      <area areaId="9" reported="11" total="73" />
+      <area areaId="10" reported="19" total="37" />
+      <area areaId="11" reported="2" total="8" />
+      <area areaId="12" reported="3" total="39" />
+      <area areaId="13" reported="7" total="35" />
+      <area areaId="14" reported="6" total="14" />
+      <area areaId="15" reported="2" total="11" />
+      <area areaId="16" reported="8" total="16" />
+      <area areaId="17" reported="9" total="20" />
+      <area areaId="18" reported="3" total="19" />
+      <area areaId="19" reported="3" total="20" />
+      <area areaId="20" reported="4" total="17" />
+      <area areaId="21" reported="9" total="18" />
+      <area areaId="22" reported="6" total="17" />
+      <area areaId="23" reported="3" total="22" />
+      <area areaId="24" reported="3" total="16" />
+      <area areaId="25" reported="6" total="19" />
+      <area areaId="26" reported="0" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="2" total="15" />
+      <area areaId="29" reported="5" total="13" />
+      <area areaId="30" reported="69" total="275" />
+      <area areaId="31" reported="69" total="275" />
+      <area areaId="32" reported="69" total="275" />
+      <area areaId="33" reported="9" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_4.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_4.xml
@@ -1,0 +1,370 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 22:15:43" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 22:15:43</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="1" ballots="71177" overvotes="17" undervotes="830" numVoters="70347" pushContests="0" />
+      <contest contestId="5" ballots="71177" overvotes="10" undervotes="1921" numVoters="69256" pushContests="0" />
+      <contest contestId="7" ballots="71177" overvotes="16" undervotes="2585" numVoters="68592" pushContests="0" />
+      <contest contestId="9" ballots="71177" overvotes="8" undervotes="6959" numVoters="64218" pushContests="0" />
+      <contest contestId="11" ballots="71177" overvotes="18" undervotes="5205" numVoters="65972" pushContests="0" />
+      <contest contestId="13" ballots="41001" overvotes="11" undervotes="2662" numVoters="38339" pushContests="0" />
+      <contest contestId="15" ballots="30176" overvotes="2" undervotes="2065" numVoters="28111" pushContests="0" />
+      <contest contestId="17" ballots="9234" overvotes="0" undervotes="1773" numVoters="7461" pushContests="0" />
+      <contest contestId="19" ballots="43818" overvotes="5" undervotes="3975" numVoters="39843" pushContests="0" />
+      <contest contestId="21" ballots="18125" overvotes="3" undervotes="4328" numVoters="13797" pushContests="0" />
+      <contest contestId="23" ballots="27173" overvotes="2" undervotes="5573" numVoters="21600" pushContests="0" />
+      <contest contestId="25" ballots="9234" overvotes="0" undervotes="1612" numVoters="7622" pushContests="0" />
+      <contest contestId="27" ballots="2606" overvotes="2" undervotes="504" numVoters="2102" pushContests="0" />
+      <contest contestId="29" ballots="8545" overvotes="0" undervotes="1751" numVoters="6794" pushContests="0" />
+      <contest contestId="31" ballots="8100" overvotes="2" undervotes="958" numVoters="7142" pushContests="0" />
+      <contest contestId="33" ballots="15519" overvotes="1" undervotes="3474" numVoters="12045" pushContests="0" />
+      <contest contestId="35" ballots="4339" overvotes="0" undervotes="823" numVoters="3516" pushContests="0" />
+      <contest contestId="37" ballots="2606" overvotes="0" undervotes="482" numVoters="2124" pushContests="0" />
+      <contest contestId="39" ballots="7227" overvotes="0" undervotes="1757" numVoters="5470" pushContests="0" />
+      <contest contestId="41" ballots="10635" overvotes="0" undervotes="2266" numVoters="8369" pushContests="0" />
+      <contest contestId="43" ballots="2604" overvotes="1" undervotes="270" numVoters="2334" pushContests="0" />
+      <contest contestId="45" ballots="1777" overvotes="0" undervotes="239" numVoters="1538" pushContests="0" />
+      <contest contestId="47" ballots="3580" overvotes="2" undervotes="527" numVoters="3053" pushContests="0" />
+      <contest contestId="49" ballots="7382" overvotes="0" undervotes="1518" numVoters="5864" pushContests="0" />
+      <contest contestId="51" ballots="5879" overvotes="0" undervotes="969" numVoters="4910" pushContests="0" />
+      <contest contestId="53" ballots="6359" overvotes="0" undervotes="1429" numVoters="4930" pushContests="0" />
+      <contest contestId="55" ballots="3489" overvotes="0" undervotes="653" numVoters="2836" pushContests="0" />
+      <contest contestId="57" ballots="3880" overvotes="0" undervotes="946" numVoters="2934" pushContests="0" />
+      <contest contestId="59" ballots="2186" overvotes="0" undervotes="322" numVoters="1864" pushContests="0" />
+      <contest contestId="63" ballots="4767" overvotes="1" undervotes="644" numVoters="4123" pushContests="0" />
+      <contest contestId="65" ballots="4467" overvotes="0" undervotes="891" numVoters="3576" pushContests="0" />
+      <contest contestId="67" ballots="71177" overvotes="7" undervotes="15711" numVoters="55466" pushContests="0" />
+      <contest contestId="69" ballots="71177" overvotes="4" undervotes="16193" numVoters="54984" pushContests="0" />
+      <contest contestId="70" ballots="71177" overvotes="22" undervotes="2935" numVoters="68242" pushContests="0" />
+      <contest contestId="71" ballots="71177" overvotes="14" undervotes="4645" numVoters="66532" pushContests="0" />
+      <contest contestId="72" ballots="70732" overvotes="26" undervotes="3389" numVoters="67343" pushContests="0" />
+      <contest contestId="73" ballots="70732" overvotes="35" undervotes="4741" numVoters="65991" pushContests="0" />
+      <contest contestId="74" ballots="7316" overvotes="0" undervotes="1472" numVoters="5844" pushContests="0" />
+      <contest contestId="75" ballots="7316" overvotes="0" undervotes="1791" numVoters="5525" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="14120" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="54979" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="1070" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="161" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="54102" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="15010" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="134" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="54735" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="2755" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="10953" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="133" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="54654" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="9214" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="342" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="2253" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="44490" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="16451" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="1496" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="1137" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="127" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="32074" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="6111" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="143" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="21844" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="6171" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="94" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="7299" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="162" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="31997" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="7726" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="115" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="13451" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="343" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="21098" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="500" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="7478" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="144" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="2075" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="25" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="6640" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="154" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="7027" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="113" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="11728" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="316" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="3414" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="102" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="2094" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="30" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="5366" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="104" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="8164" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="205" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="291" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="2016" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="26" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="1522" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="16" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="3013" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="38" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="5753" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="111" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="4838" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="72" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="4822" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="108" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="2797" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="39" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="2836" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="98" />
+      <res contId="59" chId="56" wrInd="0" prtId="0" vot="1840" />
+      <res contId="59" chId="120" wrInd="0" prtId="0" vot="24" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="4052" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="70" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="3513" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="63" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="53985" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="1474" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="53771" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="1209" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="41446" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="26774" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="52063" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="14455" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="36202" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="31115" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="45066" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="20890" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="4134" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="1710" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="4324" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="1201" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="119" total="275" />
+      <area areaId="2" reported="119" total="275" />
+      <area areaId="3" reported="76" total="189" />
+      <area areaId="4" reported="43" total="86" />
+      <area areaId="5" reported="15" total="35" />
+      <area areaId="6" reported="77" total="195" />
+      <area areaId="7" reported="27" total="45" />
+      <area areaId="8" reported="44" total="83" />
+      <area areaId="9" reported="22" total="73" />
+      <area areaId="10" reported="24" total="37" />
+      <area areaId="11" reported="3" total="8" />
+      <area areaId="12" reported="11" total="39" />
+      <area areaId="13" reported="15" total="35" />
+      <area areaId="14" reported="8" total="14" />
+      <area areaId="15" reported="3" total="11" />
+      <area areaId="16" reported="10" total="16" />
+      <area areaId="17" reported="14" total="20" />
+      <area areaId="18" reported="8" total="19" />
+      <area areaId="19" reported="5" total="20" />
+      <area areaId="20" reported="10" total="17" />
+      <area areaId="21" reported="12" total="18" />
+      <area areaId="22" reported="9" total="17" />
+      <area areaId="23" reported="8" total="22" />
+      <area areaId="24" reported="6" total="16" />
+      <area areaId="25" reported="8" total="19" />
+      <area areaId="26" reported="3" total="19" />
+      <area areaId="27" reported="0" total="19" />
+      <area areaId="28" reported="7" total="15" />
+      <area areaId="29" reported="8" total="13" />
+      <area areaId="30" reported="119" total="275" />
+      <area areaId="31" reported="119" total="275" />
+      <area areaId="32" reported="119" total="275" />
+      <area areaId="33" reported="14" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_5.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_5.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 22:22:32" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 22:22:32</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="1" ballots="82337" overvotes="20" undervotes="953" numVoters="81384" pushContests="0" />
+      <contest contestId="5" ballots="82337" overvotes="10" undervotes="2170" numVoters="80167" pushContests="0" />
+      <contest contestId="7" ballots="82337" overvotes="18" undervotes="2938" numVoters="79399" pushContests="0" />
+      <contest contestId="9" ballots="82337" overvotes="10" undervotes="7885" numVoters="74452" pushContests="0" />
+      <contest contestId="11" ballots="82337" overvotes="21" undervotes="5988" numVoters="76349" pushContests="0" />
+      <contest contestId="13" ballots="48453" overvotes="13" undervotes="3108" numVoters="45345" pushContests="0" />
+      <contest contestId="15" ballots="33884" overvotes="2" undervotes="2351" numVoters="31533" pushContests="0" />
+      <contest contestId="17" ballots="9512" overvotes="0" undervotes="1824" numVoters="7688" pushContests="0" />
+      <contest contestId="19" ballots="53066" overvotes="6" undervotes="4714" numVoters="48352" pushContests="0" />
+      <contest contestId="21" ballots="19759" overvotes="3" undervotes="4791" numVoters="14968" pushContests="0" />
+      <contest contestId="23" ballots="32379" overvotes="2" undervotes="6515" numVoters="25864" pushContests="0" />
+      <contest contestId="25" ballots="9512" overvotes="0" undervotes="1654" numVoters="7858" pushContests="0" />
+      <contest contestId="27" ballots="2606" overvotes="2" undervotes="504" numVoters="2102" pushContests="0" />
+      <contest contestId="29" ballots="10188" overvotes="0" undervotes="2123" numVoters="8065" pushContests="0" />
+      <contest contestId="31" ballots="10499" overvotes="2" undervotes="1243" numVoters="9256" pushContests="0" />
+      <contest contestId="33" ballots="17153" overvotes="1" undervotes="3890" numVoters="13263" pushContests="0" />
+      <contest contestId="35" ballots="5162" overvotes="0" undervotes="1009" numVoters="4153" pushContests="0" />
+      <contest contestId="37" ballots="2606" overvotes="0" undervotes="482" numVoters="2124" pushContests="0" />
+      <contest contestId="39" ballots="7827" overvotes="0" undervotes="1840" numVoters="5987" pushContests="0" />
+      <contest contestId="41" ballots="10635" overvotes="0" undervotes="2266" numVoters="8369" pushContests="0" />
+      <contest contestId="43" ballots="2604" overvotes="1" undervotes="270" numVoters="2334" pushContests="0" />
+      <contest contestId="45" ballots="3729" overvotes="0" undervotes="514" numVoters="3215" pushContests="0" />
+      <contest contestId="47" ballots="3704" overvotes="2" undervotes="544" numVoters="3160" pushContests="0" />
+      <contest contestId="49" ballots="8347" overvotes="0" undervotes="1713" numVoters="6634" pushContests="0" />
+      <contest contestId="51" ballots="6854" overvotes="0" undervotes="1137" numVoters="5717" pushContests="0" />
+      <contest contestId="53" ballots="8002" overvotes="0" undervotes="1813" numVoters="6189" pushContests="0" />
+      <contest contestId="55" ballots="4388" overvotes="0" undervotes="774" numVoters="3614" pushContests="0" />
+      <contest contestId="57" ballots="6166" overvotes="0" undervotes="1432" numVoters="4734" pushContests="0" />
+      <contest contestId="59" ballots="2186" overvotes="0" undervotes="322" numVoters="1864" pushContests="0" />
+      <contest contestId="61" ballots="893" overvotes="0" undervotes="151" numVoters="742" pushContests="0" />
+      <contest contestId="63" ballots="4767" overvotes="1" undervotes="644" numVoters="4123" pushContests="0" />
+      <contest contestId="65" ballots="4467" overvotes="0" undervotes="891" numVoters="3576" pushContests="0" />
+      <contest contestId="67" ballots="82337" overvotes="10" undervotes="18048" numVoters="64289" pushContests="0" />
+      <contest contestId="69" ballots="82337" overvotes="5" undervotes="18519" numVoters="63818" pushContests="0" />
+      <contest contestId="70" ballots="82337" overvotes="27" undervotes="3458" numVoters="78879" pushContests="0" />
+      <contest contestId="71" ballots="82337" overvotes="16" undervotes="5388" numVoters="76949" pushContests="0" />
+      <contest contestId="72" ballots="81841" overvotes="32" undervotes="3970" numVoters="77871" pushContests="0" />
+      <contest contestId="73" ballots="81841" overvotes="40" undervotes="5460" numVoters="76381" pushContests="0" />
+      <contest contestId="74" ballots="11373" overvotes="1" undervotes="2166" numVoters="9207" pushContests="0" />
+      <contest contestId="75" ballots="11373" overvotes="0" undervotes="2663" numVoters="8710" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="15772" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="64196" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="1213" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="183" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="63301" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="16707" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="149" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="63700" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="3261" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="12264" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="156" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="63669" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="10390" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="383" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="2647" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="52166" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="18366" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="1738" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="1269" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="142" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="38199" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="6969" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="164" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="24665" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="6758" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="108" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="7518" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="170" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="39461" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="8754" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="131" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="14593" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="372" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="25276" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="586" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="7709" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="149" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="2075" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="25" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="7893" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="172" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="9108" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="146" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="12909" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="353" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="4040" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="113" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="2094" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="30" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="5879" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="108" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="8164" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="205" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="291" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="2016" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="26" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="3175" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="40" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="3118" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="40" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="6505" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="129" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="5637" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="80" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="6065" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="124" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="3566" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="48" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="4596" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="138" />
+      <res contId="59" chId="56" wrInd="0" prtId="0" vot="1840" />
+      <res contId="59" chId="120" wrInd="0" prtId="0" vot="24" />
+      <res contId="61" chId="59" wrInd="0" prtId="0" vot="729" />
+      <res contId="61" chId="165" wrInd="0" prtId="0" vot="13" />
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="4052" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="70" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="3513" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="63" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="62550" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="1729" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="62445" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="1368" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="48597" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="30255" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="60561" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="16372" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="41984" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="35855" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="52570" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="23771" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="6705" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="2501" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="7020" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="1690" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="138" total="275" />
+      <area areaId="2" reported="138" total="275" />
+      <area areaId="3" reported="90" total="189" />
+      <area areaId="4" reported="48" total="86" />
+      <area areaId="5" reported="17" total="35" />
+      <area areaId="6" reported="92" total="195" />
+      <area areaId="7" reported="29" total="45" />
+      <area areaId="8" reported="53" total="83" />
+      <area areaId="9" reported="26" total="73" />
+      <area areaId="10" reported="26" total="37" />
+      <area areaId="11" reported="3" total="8" />
+      <area areaId="12" reported="13" total="39" />
+      <area areaId="13" reported="17" total="35" />
+      <area areaId="14" reported="9" total="14" />
+      <area areaId="15" reported="3" total="11" />
+      <area areaId="16" reported="11" total="16" />
+      <area areaId="17" reported="14" total="20" />
+      <area areaId="18" reported="8" total="19" />
+      <area areaId="19" reported="10" total="20" />
+      <area areaId="20" reported="11" total="17" />
+      <area areaId="21" reported="14" total="18" />
+      <area areaId="22" reported="10" total="17" />
+      <area areaId="23" reported="10" total="22" />
+      <area areaId="24" reported="7" total="16" />
+      <area areaId="25" reported="12" total="19" />
+      <area areaId="26" reported="3" total="19" />
+      <area areaId="27" reported="1" total="19" />
+      <area areaId="28" reported="7" total="15" />
+      <area areaId="29" reported="8" total="13" />
+      <area areaId="30" reported="138" total="275" />
+      <area areaId="31" reported="138" total="275" />
+      <area areaId="32" reported="138" total="275" />
+      <area areaId="33" reported="20" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_6.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_6.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 22:30:14" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 22:30:14</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="35469" overvotes="2" undervotes="7071" numVoters="28398" pushContests="0" />
+      <contest contestId="69" ballots="95891" overvotes="6" undervotes="21534" numVoters="74357" pushContests="0" />
+      <contest contestId="29" ballots="15046" overvotes="0" undervotes="3194" numVoters="11852" pushContests="0" />
+      <contest contestId="75" ballots="13734" overvotes="1" undervotes="3204" numVoters="10530" pushContests="0" />
+      <contest contestId="9" ballots="95891" overvotes="10" undervotes="9145" numVoters="86746" pushContests="0" />
+      <contest contestId="15" ballots="39691" overvotes="2" undervotes="2747" numVoters="36944" pushContests="0" />
+      <contest contestId="72" ballots="95306" overvotes="39" undervotes="4540" numVoters="90766" pushContests="0" />
+      <contest contestId="35" ballots="5637" overvotes="0" undervotes="1090" numVoters="4547" pushContests="0" />
+      <contest contestId="63" ballots="4767" overvotes="1" undervotes="644" numVoters="4123" pushContests="0" />
+      <contest contestId="55" ballots="5650" overvotes="0" undervotes="979" numVoters="4671" pushContests="0" />
+      <contest contestId="43" ballots="3209" overvotes="1" undervotes="306" numVoters="2903" pushContests="0" />
+      <contest contestId="49" ballots="9301" overvotes="0" undervotes="1916" numVoters="7385" pushContests="0" />
+      <contest contestId="67" ballots="95891" overvotes="15" undervotes="20993" numVoters="74898" pushContests="0" />
+      <contest contestId="21" ballots="21821" overvotes="3" undervotes="5302" numVoters="16519" pushContests="0" />
+      <contest contestId="27" ballots="2606" overvotes="2" undervotes="504" numVoters="2102" pushContests="0" />
+      <contest contestId="7" ballots="95891" overvotes="19" undervotes="3359" numVoters="92532" pushContests="0" />
+      <contest contestId="1" ballots="95891" overvotes="25" undervotes="1110" numVoters="94781" pushContests="0" />
+      <contest contestId="47" ballots="4324" overvotes="2" undervotes="661" numVoters="3663" pushContests="0" />
+      <contest contestId="70" ballots="95891" overvotes="32" undervotes="4070" numVoters="91821" pushContests="0" />
+      <contest contestId="61" ballots="1399" overvotes="0" undervotes="228" numVoters="1171" pushContests="0" />
+      <contest contestId="41" ballots="12401" overvotes="0" undervotes="2611" numVoters="9790" pushContests="0" />
+      <contest contestId="65" ballots="4467" overvotes="0" undervotes="891" numVoters="3576" pushContests="0" />
+      <contest contestId="19" ballots="64558" overvotes="7" undervotes="5711" numVoters="58847" pushContests="0" />
+      <contest contestId="73" ballots="95306" overvotes="47" undervotes="6356" numVoters="88950" pushContests="0" />
+      <contest contestId="25" ballots="9512" overvotes="0" undervotes="1654" numVoters="7858" pushContests="0" />
+      <contest contestId="13" ballots="56200" overvotes="14" undervotes="3592" numVoters="52608" pushContests="0" />
+      <contest contestId="5" ballots="95891" overvotes="10" undervotes="2523" numVoters="93368" pushContests="0" />
+      <contest contestId="59" ballots="5197" overvotes="1" undervotes="910" numVoters="4287" pushContests="0" />
+      <contest contestId="39" ballots="8460" overvotes="0" undervotes="1969" numVoters="6491" pushContests="0" />
+      <contest contestId="33" ballots="19215" overvotes="2" undervotes="4350" numVoters="14865" pushContests="0" />
+      <contest contestId="53" ballots="9849" overvotes="0" undervotes="2212" numVoters="7637" pushContests="0" />
+      <contest contestId="45" ballots="4397" overvotes="0" undervotes="599" numVoters="3798" pushContests="0" />
+      <contest contestId="71" ballots="95891" overvotes="20" undervotes="6251" numVoters="89640" pushContests="0" />
+      <contest contestId="17" ballots="9512" overvotes="0" undervotes="1824" numVoters="7688" pushContests="0" />
+      <contest contestId="31" ballots="14043" overvotes="2" undervotes="1680" numVoters="12363" pushContests="0" />
+      <contest contestId="11" ballots="95891" overvotes="25" undervotes="6957" numVoters="88934" pushContests="0" />
+      <contest contestId="74" ballots="13734" overvotes="1" undervotes="2575" numVoters="11159" pushContests="0" />
+      <contest contestId="57" ballots="6773" overvotes="0" undervotes="1541" numVoters="5232" pushContests="0" />
+      <contest contestId="37" ballots="2606" overvotes="0" undervotes="482" numVoters="2124" pushContests="0" />
+      <contest contestId="51" ballots="7454" overvotes="0" undervotes="1241" numVoters="6213" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="4052" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="3513" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="27" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="406" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="42024" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="48137" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="174" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="70518" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="10539" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="30" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="25" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="56817" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="1571" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="74231" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="2003" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="150" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="334" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="4422" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="3614" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="8220" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="48703" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="6373" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="1994" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="2075" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="73826" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="4619" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="9557" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="28890" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="27838" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="164" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="19102" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="170" />
+      <res contId="61" chId="165" wrInd="0" prtId="0" vot="16" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="7996" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="60966" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="21209" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="5082" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="7245" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="74831" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="641" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="44419" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="182" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="219" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="44" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="16110" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="52" />
+      <res contId="59" chId="56" wrInd="0" prtId="0" vot="4227" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="27755" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="72889" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="3082" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="7709" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="249" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="63" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="1401" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="451" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="125" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="172" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="14468" />
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="18305" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="61065" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="7481" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="12040" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="7518" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="123" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="92" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="395" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="7929" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="8519" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="2094" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="233" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="74245" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="118" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="156" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="70" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="2010" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="1475" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="14257" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="6121" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="47" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="3754" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="2541" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="72780" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="179" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="11603" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="140" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="177" />
+      <res contId="61" chId="59" wrInd="0" prtId="0" vot="1155" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="34972" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="149" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="12184" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="3843" />
+      <res contId="59" chId="120" wrInd="0" prtId="0" vot="59" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="19360" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="2938" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="158" total="275" />
+      <area areaId="2" reported="158" total="275" />
+      <area areaId="3" reported="103" total="189" />
+      <area areaId="4" reported="55" total="86" />
+      <area areaId="5" reported="17" total="35" />
+      <area areaId="6" reported="109" total="195" />
+      <area areaId="7" reported="32" total="45" />
+      <area areaId="8" reported="57" total="83" />
+      <area areaId="9" reported="33" total="73" />
+      <area areaId="10" reported="29" total="37" />
+      <area areaId="11" reported="3" total="8" />
+      <area areaId="12" reported="19" total="39" />
+      <area areaId="13" reported="17" total="35" />
+      <area areaId="14" reported="10" total="14" />
+      <area areaId="15" reported="3" total="11" />
+      <area areaId="16" reported="12" total="16" />
+      <area areaId="17" reported="16" total="20" />
+      <area areaId="18" reported="9" total="19" />
+      <area areaId="19" reported="11" total="20" />
+      <area areaId="20" reported="13" total="17" />
+      <area areaId="21" reported="15" total="18" />
+      <area areaId="22" reported="11" total="17" />
+      <area areaId="23" reported="12" total="22" />
+      <area areaId="24" reported="9" total="16" />
+      <area areaId="25" reported="13" total="19" />
+      <area areaId="26" reported="7" total="19" />
+      <area areaId="27" reported="2" total="19" />
+      <area areaId="28" reported="7" total="15" />
+      <area areaId="29" reported="8" total="13" />
+      <area areaId="30" reported="158" total="275" />
+      <area areaId="31" reported="158" total="275" />
+      <area areaId="32" reported="158" total="275" />
+      <area areaId="33" reported="24" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_7.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_7.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 23:01:21" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 23:01:21</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="42953" overvotes="2" undervotes="8418" numVoters="34535" pushContests="0" />
+      <contest contestId="69" ballots="128398" overvotes="9" undervotes="27897" numVoters="100501" pushContests="0" />
+      <contest contestId="29" ballots="19376" overvotes="0" undervotes="4006" numVoters="15370" pushContests="0" />
+      <contest contestId="75" ballots="22755" overvotes="1" undervotes="5224" numVoters="17531" pushContests="0" />
+      <contest contestId="9" ballots="128398" overvotes="13" undervotes="11829" numVoters="116569" pushContests="0" />
+      <contest contestId="15" ballots="46325" overvotes="2" undervotes="3210" numVoters="43115" pushContests="0" />
+      <contest contestId="72" ballots="127626" overvotes="55" undervotes="6129" numVoters="121497" pushContests="0" />
+      <contest contestId="35" ballots="6744" overvotes="0" undervotes="1283" numVoters="5461" pushContests="0" />
+      <contest contestId="63" ballots="7814" overvotes="1" undervotes="1106" numVoters="6708" pushContests="0" />
+      <contest contestId="55" ballots="9009" overvotes="0" undervotes="1439" numVoters="7570" pushContests="0" />
+      <contest contestId="43" ballots="6163" overvotes="1" undervotes="560" numVoters="5603" pushContests="0" />
+      <contest contestId="49" ballots="10401" overvotes="0" undervotes="2098" numVoters="8303" pushContests="0" />
+      <contest contestId="67" ballots="128398" overvotes="22" undervotes="27428" numVoters="100970" pushContests="0" />
+      <contest contestId="21" ballots="25558" overvotes="3" undervotes="6159" numVoters="19399" pushContests="0" />
+      <contest contestId="27" ballots="4642" overvotes="2" undervotes="955" numVoters="3687" pushContests="0" />
+      <contest contestId="7" ballots="128398" overvotes="29" undervotes="4468" numVoters="123930" pushContests="0" />
+      <contest contestId="1" ballots="128398" overvotes="39" undervotes="1513" numVoters="126885" pushContests="0" />
+      <contest contestId="47" ballots="6040" overvotes="2" undervotes="883" numVoters="5157" pushContests="0" />
+      <contest contestId="70" ballots="128398" overvotes="42" undervotes="5668" numVoters="122730" pushContests="0" />
+      <contest contestId="61" ballots="5465" overvotes="2" undervotes="890" numVoters="4575" pushContests="0" />
+      <contest contestId="41" ballots="13749" overvotes="0" undervotes="2882" numVoters="10867" pushContests="0" />
+      <contest contestId="65" ballots="6539" overvotes="0" undervotes="1252" numVoters="5287" pushContests="0" />
+      <contest contestId="19" ballots="87109" overvotes="11" undervotes="7606" numVoters="79503" pushContests="0" />
+      <contest contestId="73" ballots="127626" overvotes="55" undervotes="8431" numVoters="119195" pushContests="0" />
+      <contest contestId="25" ballots="15731" overvotes="0" undervotes="2741" numVoters="12990" pushContests="0" />
+      <contest contestId="13" ballots="82073" overvotes="16" undervotes="5080" numVoters="76993" pushContests="0" />
+      <contest contestId="5" ballots="128398" overvotes="12" undervotes="3234" numVoters="125164" pushContests="0" />
+      <contest contestId="59" ballots="7675" overvotes="1" undervotes="1272" numVoters="6403" pushContests="0" />
+      <contest contestId="39" ballots="9054" overvotes="0" undervotes="2073" numVoters="6981" pushContests="0" />
+      <contest contestId="33" ballots="20916" overvotes="2" undervotes="4659" numVoters="16257" pushContests="0" />
+      <contest contestId="53" ballots="12000" overvotes="1" undervotes="2673" numVoters="9327" pushContests="0" />
+      <contest contestId="45" ballots="7114" overvotes="0" undervotes="982" numVoters="6132" pushContests="0" />
+      <contest contestId="71" ballots="128398" overvotes="28" undervotes="8562" numVoters="119836" pushContests="0" />
+      <contest contestId="17" ballots="15731" overvotes="0" undervotes="3050" numVoters="12681" pushContests="0" />
+      <contest contestId="31" ballots="24780" overvotes="2" undervotes="3017" numVoters="21763" pushContests="0" />
+      <contest contestId="11" ballots="128398" overvotes="35" undervotes="9167" numVoters="119231" pushContests="0" />
+      <contest contestId="74" ballots="22755" overvotes="3" undervotes="4189" numVoters="18566" pushContests="0" />
+      <contest contestId="57" ballots="8411" overvotes="1" undervotes="1968" numVoters="6443" pushContests="0" />
+      <contest contestId="37" ballots="4642" overvotes="0" undervotes="922" numVoters="3720" pushContests="0" />
+      <contest contestId="51" ballots="7578" overvotes="0" undervotes="1265" numVoters="6313" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="6591" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="5197" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="44" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="462" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="55897" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="66292" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="227" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="95153" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="12981" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="50" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="50" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="78582" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="2091" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="100287" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="2827" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="179" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="638" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="5317" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="5083" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="14174" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="65545" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="6854" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="2725" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="3635" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="100898" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="7488" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="10600" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="34015" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="35895" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="219" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="24655" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="277" />
+      <res contId="61" chId="165" wrInd="0" prtId="0" vot="62" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="11099" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="83443" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="26353" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="6263" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="8150" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="101927" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="788" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="65623" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="238" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="287" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="91" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="18934" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="82" />
+      <res contId="59" chId="56" wrInd="0" prtId="0" vot="6316" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="33745" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="98223" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="4469" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="12758" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="309" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="90" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="1824" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="587" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="144" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="220" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="15820" />
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="22808" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="83245" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="9142" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="15368" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="12404" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="154" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="95" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="435" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="8944" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="14502" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="3670" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="267" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="100601" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="127" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="184" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="116" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="3028" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="1877" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="17861" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="6218" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="72" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="6041" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="4920" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="98401" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="255" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="15061" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="153" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="293" />
+      <res contId="61" chId="59" wrInd="0" prtId="0" vot="4511" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="44106" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="232" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="21468" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="5515" />
+      <res contId="59" chId="120" wrInd="0" prtId="0" vot="86" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="24034" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="4389" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="220" total="275" />
+      <area areaId="2" reported="220" total="275" />
+      <area areaId="3" reported="155" total="189" />
+      <area areaId="4" reported="65" total="86" />
+      <area areaId="5" reported="28" total="35" />
+      <area areaId="6" reported="154" total="195" />
+      <area areaId="7" reported="38" total="45" />
+      <area areaId="8" reported="73" total="83" />
+      <area areaId="9" reported="55" total="73" />
+      <area areaId="10" reported="32" total="37" />
+      <area areaId="11" reported="6" total="8" />
+      <area areaId="12" reported="26" total="39" />
+      <area areaId="13" reported="28" total="35" />
+      <area areaId="14" reported="12" total="14" />
+      <area areaId="15" reported="6" total="11" />
+      <area areaId="16" reported="13" total="16" />
+      <area areaId="17" reported="18" total="20" />
+      <area areaId="18" reported="17" total="19" />
+      <area areaId="19" reported="18" total="20" />
+      <area areaId="20" reported="17" total="17" />
+      <area areaId="21" reported="17" total="18" />
+      <area areaId="22" reported="12" total="17" />
+      <area areaId="23" reported="15" total="22" />
+      <area areaId="24" reported="15" total="16" />
+      <area areaId="25" reported="15" total="19" />
+      <area areaId="26" reported="12" total="19" />
+      <area areaId="27" reported="9" total="19" />
+      <area areaId="28" reported="12" total="15" />
+      <area areaId="29" reported="12" total="13" />
+      <area areaId="30" reported="220" total="275" />
+      <area areaId="31" reported="220" total="275" />
+      <area areaId="32" reported="220" total="275" />
+      <area areaId="33" reported="39" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_8.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_8.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-08 23:42:59" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-08 23:42:59</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="50763" overvotes="4" undervotes="10121" numVoters="40642" pushContests="0" />
+      <contest contestId="69" ballots="173964" overvotes="13" undervotes="37866" numVoters="135558" pushContests="0" />
+      <contest contestId="29" ballots="31217" overvotes="1" undervotes="6587" numVoters="24630" pushContests="0" />
+      <contest contestId="75" ballots="35611" overvotes="3" undervotes="7595" numVoters="28016" pushContests="0" />
+      <contest contestId="9" ballots="173964" overvotes="21" undervotes="15730" numVoters="157694" pushContests="0" />
+      <contest contestId="15" ballots="64164" overvotes="5" undervotes="4561" numVoters="59603" pushContests="0" />
+      <contest contestId="72" ballots="172887" overvotes="73" undervotes="8413" numVoters="163943" pushContests="0" />
+      <contest contestId="35" ballots="8590" overvotes="0" undervotes="1605" numVoters="6985" pushContests="0" />
+      <contest contestId="63" ballots="9564" overvotes="1" undervotes="1373" numVoters="8191" pushContests="0" />
+      <contest contestId="55" ballots="9842" overvotes="1" undervotes="1554" numVoters="8288" pushContests="0" />
+      <contest contestId="43" ballots="7137" overvotes="1" undervotes="633" numVoters="6504" pushContests="0" />
+      <contest contestId="49" ballots="11769" overvotes="0" undervotes="2341" numVoters="9428" pushContests="0" />
+      <contest contestId="67" ballots="173964" overvotes="32" undervotes="37560" numVoters="135864" pushContests="0" />
+      <contest contestId="21" ballots="33255" overvotes="4" undervotes="7983" numVoters="25272" pushContests="0" />
+      <contest contestId="27" ballots="7379" overvotes="2" undervotes="1521" numVoters="5858" pushContests="0" />
+      <contest contestId="7" ballots="173964" overvotes="43" undervotes="5946" numVoters="167478" pushContests="0" />
+      <contest contestId="1" ballots="173964" overvotes="54" undervotes="2066" numVoters="171358" pushContests="0" />
+      <contest contestId="47" ballots="6040" overvotes="2" undervotes="883" numVoters="5157" pushContests="0" />
+      <contest contestId="70" ballots="173964" overvotes="56" undervotes="7335" numVoters="166089" pushContests="0" />
+      <contest contestId="61" ballots="14494" overvotes="2" undervotes="2000" numVoters="12494" pushContests="0" />
+      <contest contestId="41" ballots="14546" overvotes="0" undervotes="3036" numVoters="11510" pushContests="0" />
+      <contest contestId="65" ballots="7196" overvotes="0" undervotes="1363" numVoters="5833" pushContests="0" />
+      <contest contestId="19" ballots="121086" overvotes="19" undervotes="10416" numVoters="110130" pushContests="0" />
+      <contest contestId="73" ballots="172887" overvotes="76" undervotes="11126" numVoters="161230" pushContests="0" />
+      <contest contestId="25" ballots="19623" overvotes="0" undervotes="3315" numVoters="16308" pushContests="0" />
+      <contest contestId="13" ballots="109800" overvotes="18" undervotes="6807" numVoters="102453" pushContests="0" />
+      <contest contestId="5" ballots="173964" overvotes="18" undervotes="4295" numVoters="169129" pushContests="0" />
+      <contest contestId="59" ballots="13719" overvotes="2" undervotes="2256" numVoters="11463" pushContests="0" />
+      <contest contestId="39" ballots="11611" overvotes="0" undervotes="2615" numVoters="8996" pushContests="0" />
+      <contest contestId="33" ballots="25876" overvotes="2" undervotes="5678" numVoters="20198" pushContests="0" />
+      <contest contestId="53" ballots="18456" overvotes="1" undervotes="4242" numVoters="14214" pushContests="0" />
+      <contest contestId="45" ballots="8922" overvotes="0" undervotes="1303" numVoters="7619" pushContests="0" />
+      <contest contestId="71" ballots="173964" overvotes="36" undervotes="11179" numVoters="162245" pushContests="0" />
+      <contest contestId="17" ballots="19623" overvotes="0" undervotes="3676" numVoters="15947" pushContests="0" />
+      <contest contestId="31" ballots="39106" overvotes="2" undervotes="4672" numVoters="33894" pushContests="0" />
+      <contest contestId="11" ballots="173964" overvotes="50" undervotes="12248" numVoters="161176" pushContests="0" />
+      <contest contestId="74" ballots="35611" overvotes="5" undervotes="6063" numVoters="29548" pushContests="0" />
+      <contest contestId="57" ballots="11530" overvotes="3" undervotes="2724" numVoters="8806" pushContests="0" />
+      <contest contestId="37" ballots="8864" overvotes="0" undervotes="1737" numVoters="7127" pushContests="0" />
+      <contest contestId="51" ballots="11684" overvotes="0" undervotes="1912" numVoters="9232" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="8054" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="5735" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="44" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="591" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="74975" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="92644" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="296" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="129849" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="111" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="17672" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="95" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="107804" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="2733" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="136234" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="3867" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="251" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="730" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="6820" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="5083" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="23325" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="89398" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="8842" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="3635" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="5761" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="137477" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="8197" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="11231" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="47528" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="47213" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="286" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="32855" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="340" />
+      <res contId="61" chId="165" wrInd="0" prtId="0" vot="128" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="14985" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="113503" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="35270" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="8552" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="9255" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="138775" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="909" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="87615" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="316" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="365" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="105" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="24677" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="90" />
+      <res contId="59" chId="56" wrInd="0" prtId="0" vot="11315" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="39729" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="132644" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="6197" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="16027" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="499" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="98" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="2416" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="759" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="165" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="289" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="19678" />
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="30278" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="114421" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="13938" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="20267" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="15607" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="234" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="139" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="518" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="11836" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="7016" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="24104" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="279" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="137147" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="154" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="275" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="136" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="3909" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="2496" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="23626" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="9549" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="72" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="7514" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="5729" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="133266" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="344" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="24130" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="173" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="408" />
+      <res contId="61" chId="59" wrInd="0" prtId="0" vot="12364" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="58725" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="281" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="33940" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="7783" />
+      <res contId="59" chId="120" wrInd="0" prtId="0" vot="146" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="31870" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="6218" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="274" total="275" />
+      <area areaId="2" reported="274" total="275" />
+      <area areaId="3" reported="189" total="189" />
+      <area areaId="4" reported="85" total="86" />
+      <area areaId="5" reported="35" total="35" />
+      <area areaId="6" reported="194" total="195" />
+      <area areaId="7" reported="45" total="45" />
+      <area areaId="8" reported="82" total="83" />
+      <area areaId="9" reported="73" total="73" />
+      <area areaId="10" reported="37" total="37" />
+      <area areaId="11" reported="8" total="8" />
+      <area areaId="12" reported="39" total="39" />
+      <area areaId="13" reported="35" total="35" />
+      <area areaId="14" reported="14" total="14" />
+      <area areaId="15" reported="11" total="11" />
+      <area areaId="16" reported="16" total="16" />
+      <area areaId="17" reported="19" total="20" />
+      <area areaId="18" reported="19" total="19" />
+      <area areaId="19" reported="20" total="20" />
+      <area areaId="20" reported="17" total="17" />
+      <area areaId="21" reported="18" total="18" />
+      <area areaId="22" reported="17" total="17" />
+      <area areaId="23" reported="22" total="22" />
+      <area areaId="24" reported="16" total="16" />
+      <area areaId="25" reported="19" total="19" />
+      <area areaId="26" reported="19" total="19" />
+      <area areaId="27" reported="19" total="19" />
+      <area areaId="28" reported="15" total="15" />
+      <area areaId="29" reported="13" total="13" />
+      <area areaId="30" reported="274" total="275" />
+      <area areaId="31" reported="274" total="275" />
+      <area areaId="32" reported="274" total="275" />
+      <area areaId="33" reported="54" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_9.xml
+++ b/docroot/modules/custom/bos_content/modules/node_elections/tmp/Contest_Overview_Data_2022_11_08T21_19_26_9.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" standalone="yes"?>
+<ExportName>
+   <Terminology Subdivision="District" Subdivisions="Districts" PollingSubdivision="Precinct" PollingSubdivisions="Precincts" ParentSubdivision="Parent District" MultiPollingSubdivisionCollection="Multi-Precinct Collection" />
+   <Report_Info name="BOSTON STATE ELECTION NOVEMBER 2022" Report="Contest Overview Data" Create="2022-11-09 00:02:09" unofficial="Unofficial">
+      <Information Description="Election Project Name">BOSTON STATE ELECTION NOVEMBER 2022</Information>
+      <Information Description="Report Name">Contest Overview Data</Information>
+      <Information Description="Creation Date">2022-11-09 00:02:09</Information>
+      <Information Description="Note">Results are unofficial</Information>
+   </Report_Info>
+   <settings>
+      <ch ignoreSplits="1" officialResults="0" useCustomTitle="0" showFilters="1" />
+   </settings>
+   <contests>
+      <contest contestId="1" name="GOVERNOR &amp; LT. GOVERNOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4931" />
+      <contest contestId="5" name="ATTORNEY GENERAL" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4935" />
+      <contest contestId="7" name="SECRETARY OF STATE" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4937" />
+      <contest contestId="9" name="TREASURER" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4939" />
+      <contest contestId="11" name="AUDITOR" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="4941" />
+      <contest contestId="13" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;SEVENTH DISTRICT" pos="1" writeins="1" eligible="308549" isAcclaimed="0" isDisabled="0" areaId="3" areaName="SEVENTH DISTRICT" isMajor="0" sortOrder="4943" />
+      <contest contestId="15" name="REPRESENTATIVE IN CONGRESS &#xD;&#xA;EIGHTH DISTRICT" pos="1" writeins="1" eligible="139307" isAcclaimed="0" isDisabled="0" areaId="4" areaName="EIGHTH DISTRICT" isMajor="0" sortOrder="4945" />
+      <contest contestId="17" name="COUNCILLOR &#xD;&#xA;THIRD DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="5" areaName="THIRD DISTRICT" isMajor="0" sortOrder="4947" />
+      <contest contestId="19" name="COUNCILLOR &#xD;&#xA;FOURTH DISTRICT" pos="1" writeins="1" eligible="312476" isAcclaimed="0" isDisabled="0" areaId="6" areaName="FOURTH DISTRICT" isMajor="0" sortOrder="4949" />
+      <contest contestId="21" name="COUNCILLOR &#xD;&#xA;SIXTH DISTRICT" pos="1" writeins="1" eligible="79944" isAcclaimed="0" isDisabled="0" areaId="7" areaName="SIXTH DISTRICT" isMajor="0" sortOrder="4951" />
+      <contest contestId="23" name="SENATOR IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="133893" isAcclaimed="0" isDisabled="0" areaId="8" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4953" />
+      <contest contestId="25" name="SENATOR IN GENERAL COURT &#xD;&#xA;SUFFOLK &amp; MIDDLESEX DISTRICT" pos="1" writeins="1" eligible="55436" isAcclaimed="0" isDisabled="0" areaId="13" areaName="SUFFOLK &amp; MIDDLESEX DISTRICT" isMajor="0" sortOrder="4955" />
+      <contest contestId="27" name="SENATOR IN GENERAL COURT &#xD;&#xA;MIDDLESEX &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="15418" isAcclaimed="0" isDisabled="0" areaId="11" areaName="MIDDLESEX &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4957" />
+      <contest contestId="29" name="SENATOR IN GENERAL COURT &#xD;&#xA;NORFOLK &amp; SUFFOLK DISTRICT" pos="1" writeins="1" eligible="61078" isAcclaimed="0" isDisabled="0" areaId="12" areaName="NORFOLK &amp; SUFFOLK DISTRICT" isMajor="0" sortOrder="4959" />
+      <contest contestId="31" name="SENATOR IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="117505" isAcclaimed="0" isDisabled="0" areaId="9" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4961" />
+      <contest contestId="33" name="SENATOR IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="64526" isAcclaimed="0" isDisabled="0" areaId="10" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4963" />
+      <contest contestId="35" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIRST SUFFOLK DISTRICT" pos="1" writeins="1" eligible="23814" isAcclaimed="0" isDisabled="0" areaId="14" areaName="FIRST SUFFOLK DISTRICT" isMajor="0" sortOrder="4965" />
+      <contest contestId="37" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SECOND SUFFOLK DISTRICT" pos="1" writeins="1" eligible="20257" isAcclaimed="0" isDisabled="0" areaId="15" areaName="SECOND SUFFOLK DISTRICT" isMajor="0" sortOrder="4967" />
+      <contest contestId="39" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRD SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28587" isAcclaimed="0" isDisabled="0" areaId="16" areaName="THIRD SUFFOLK DISTRICT" isMajor="0" sortOrder="4969" />
+      <contest contestId="41" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="37056" isAcclaimed="0" isDisabled="0" areaId="17" areaName="FOURTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4971" />
+      <contest contestId="43" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28511" isAcclaimed="0" isDisabled="0" areaId="18" areaName="FIFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4973" />
+      <contest contestId="45" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SIXTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29065" isAcclaimed="0" isDisabled="0" areaId="19" areaName="SIXTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4975" />
+      <contest contestId="47" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="21246" isAcclaimed="0" isDisabled="0" areaId="20" areaName="SEVENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4977" />
+      <contest contestId="49" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="28275" isAcclaimed="0" isDisabled="0" areaId="21" areaName="EIGHTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4979" />
+      <contest contestId="51" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;NINTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="31415" isAcclaimed="0" isDisabled="0" areaId="22" areaName="NINTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4981" />
+      <contest contestId="53" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32285" isAcclaimed="0" isDisabled="0" areaId="23" areaName="TENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4983" />
+      <contest contestId="55" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;TWELFTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="25720" isAcclaimed="0" isDisabled="0" areaId="24" areaName="TWELFTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4985" />
+      <contest contestId="57" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;THIRTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="29171" isAcclaimed="0" isDisabled="0" areaId="25" areaName="THIRTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4987" />
+      <contest contestId="59" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FOURTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="32389" isAcclaimed="0" isDisabled="0" areaId="26" areaName="FOURTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4989" />
+      <contest contestId="61" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;FIFTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="33715" isAcclaimed="0" isDisabled="0" areaId="27" areaName="FIFTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4991" />
+      <contest contestId="63" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;SEVENTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="26860" isAcclaimed="0" isDisabled="0" areaId="28" areaName="SEVENTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4993" />
+      <contest contestId="65" name="REPRESENTATIVE IN GENERAL COURT &#xD;&#xA;EIGHTEENTH SUFFOLK DISTRICT" pos="1" writeins="1" eligible="19490" isAcclaimed="0" isDisabled="0" areaId="29" areaName="EIGHTEENTH SUFFOLK DISTRICT" isMajor="0" sortOrder="4995" />
+      <contest contestId="67" name="DISTRICT ATTORNEY &#xD;&#xA;SUFFOLK DISTRICT" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="31" areaName="SUFFOLK DISTRICT" isMajor="0" sortOrder="4997" />
+      <contest contestId="69" name="SHERIFF &#xD;&#xA;SUFFOLK COUNTY" pos="1" writeins="1" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="32" areaName="SUFFOLK COUNTY" isMajor="0" sortOrder="4999" />
+      <contest contestId="70" name="QUESTION 1" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5001" />
+      <contest contestId="71" name="QUESTION 2" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5002" />
+      <contest contestId="72" name="QUESTION 3" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5003" />
+      <contest contestId="73" name="QUESTION 4" pos="1" writeins="0" eligible="447856" isAcclaimed="0" isDisabled="0" areaId="1" areaName="STATEWIDE" isMajor="0" sortOrder="5004" />
+      <contest contestId="74" name="QUESTION 5" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5009" />
+      <contest contestId="75" name="QUESTION 6" pos="1" writeins="0" eligible="88606" isAcclaimed="0" isDisabled="0" areaId="33" areaName="QUESTIONS" isMajor="0" sortOrder="5010" />
+   </contests>
+   <choices>
+      <ch conId="1" chId="1" name="DIEHL and ALLEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="2" name="HEALEY and DRISCOLL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="143" name="REED and EVERETT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="1" chId="167" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="6" name="ANDREA JOY CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="140" name="JAMES R. McMAHON, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="5" chId="162" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="9" name="WILLIAM FRANCIS GALVIN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="139" name="RAYLA CAMPBELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="10" name="JUAN SANCHEZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="7" chId="169" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="11" name="DEBORAH B. GOLDBERG" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="144" name="CRISTINA CRAWFORD" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="9" chId="174" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="138" name="ANTHONY AMORE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="13" name="DIANA DiZOGLIO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="12" name="GLORIA A. CABALLERO-ROCA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="145" name="DOMINIC GIANNONE, III" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="146" name="DANIEL RIEK" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="11" chId="164" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="21" name="AYANNA S. PRESSLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="137" name="DONNIE DIONICIO PALMER, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="13" chId="160" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="23" name="STEPHEN F. LYNCH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="135" name="ROBERT G. BURKE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="15" chId="168" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="26" name="MARILYN M. PETITTO DEVANEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="17" chId="171" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="28" name="CHRISTOPHER A. IANNELLA, JR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="134" name="HELENE &quot;TEDDY&quot; MacNEAL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="19" chId="170" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="29" name="TERRENCE W. KENNEDY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="21" chId="166" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="31" name="NICHOLAS P. COLLINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="23" chId="117" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="32" name="WILLIAM N. BROWNSBERGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="25" chId="108" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="33" name="SAL N. DiDOMENICO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="27" chId="119" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="34" name="MICHAEL F. RUSH" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="29" chId="100" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="38" name="LIZ MIRANDA" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="31" chId="163" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="40" name="LYDIA MARIE EDWARDS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="33" chId="71" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="41" name="ADRIAN C. MADARO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="35" chId="127" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="42" name="DANIEL JOSEPH RYAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="37" chId="133" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="43" name="AARON M. MICHLEWITZ" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="39" chId="116" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="44" name="DAVID M. BIELE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="41" chId="99" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="47" name="CHRISTOPHER J. WORRELL" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="45" name="ROY A. OWENS, SR." dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="43" chId="173" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="48" name="RUSSELL E. HOLMES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="45" chId="159" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="50" name="CHYNAH T. TYLER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="47" chId="69" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="51" name="JAY D. LIVINGSTONE" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="49" chId="107" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="52" name="JON SANTIAGO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="51" chId="70" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="53" name="EDWARD FRANCIS COPPINGER" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="53" chId="93" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="54" name="BRANDY FLUKER OAKLEY" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="55" chId="74" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="55" name="DANIEL J. HUNT" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="57" chId="126" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="56" name="ROB CONSALVO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="59" chId="120" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="59" name="SAMANTHA MONTAÑO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="61" chId="165" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="61" name="KEVIN G. HONAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="63" chId="105" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="62" name="MICHAEL J. MORAN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="65" chId="122" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="63" name="KEVIN R. HAYDEN" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="67" chId="172" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="65" name="STEVEN W. TOMPKINS" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="69" chId="161" name="Write-in" dis="0" wri="1" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="147" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="70" chId="148" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="149" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="71" chId="150" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="151" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="72" chId="152" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="153" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="73" chId="154" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="155" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="74" chId="156" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="157" name="YES" dis="0" wri="0" wrInd="0" showVotes="1" />
+      <ch conId="75" chId="158" name="NO" dis="0" wri="0" wrInd="0" showVotes="1" />
+   </choices>
+   <parties />
+   <affiliations />
+   <conteststats>
+      <contest contestId="23" ballots="50763" overvotes="4" undervotes="10121" numVoters="40642" pushContests="0" />
+      <contest contestId="69" ballots="173964" overvotes="13" undervotes="37866" numVoters="135558" pushContests="0" />
+      <contest contestId="29" ballots="31217" overvotes="1" undervotes="6587" numVoters="24630" pushContests="0" />
+      <contest contestId="75" ballots="35611" overvotes="3" undervotes="7595" numVoters="28016" pushContests="0" />
+      <contest contestId="9" ballots="173964" overvotes="21" undervotes="15730" numVoters="157694" pushContests="0" />
+      <contest contestId="15" ballots="64164" overvotes="5" undervotes="4561" numVoters="59603" pushContests="0" />
+      <contest contestId="72" ballots="172887" overvotes="73" undervotes="8413" numVoters="163943" pushContests="0" />
+      <contest contestId="35" ballots="8590" overvotes="0" undervotes="1605" numVoters="6985" pushContests="0" />
+      <contest contestId="63" ballots="9564" overvotes="1" undervotes="1373" numVoters="8191" pushContests="0" />
+      <contest contestId="55" ballots="9842" overvotes="1" undervotes="1554" numVoters="8288" pushContests="0" />
+      <contest contestId="43" ballots="7137" overvotes="1" undervotes="633" numVoters="6504" pushContests="0" />
+      <contest contestId="49" ballots="11769" overvotes="0" undervotes="2341" numVoters="9428" pushContests="0" />
+      <contest contestId="67" ballots="173964" overvotes="32" undervotes="37560" numVoters="135864" pushContests="0" />
+      <contest contestId="21" ballots="33255" overvotes="4" undervotes="7983" numVoters="25272" pushContests="0" />
+      <contest contestId="27" ballots="7379" overvotes="2" undervotes="1521" numVoters="5858" pushContests="0" />
+      <contest contestId="7" ballots="173964" overvotes="43" undervotes="5946" numVoters="167478" pushContests="0" />
+      <contest contestId="1" ballots="173964" overvotes="54" undervotes="2066" numVoters="171358" pushContests="0" />
+      <contest contestId="47" ballots="6040" overvotes="2" undervotes="883" numVoters="5157" pushContests="0" />
+      <contest contestId="70" ballots="173964" overvotes="56" undervotes="7335" numVoters="166089" pushContests="0" />
+      <contest contestId="61" ballots="14494" overvotes="2" undervotes="2000" numVoters="12494" pushContests="0" />
+      <contest contestId="41" ballots="14546" overvotes="0" undervotes="3036" numVoters="11510" pushContests="0" />
+      <contest contestId="65" ballots="7196" overvotes="0" undervotes="1363" numVoters="5833" pushContests="0" />
+      <contest contestId="19" ballots="121086" overvotes="19" undervotes="10416" numVoters="110130" pushContests="0" />
+      <contest contestId="73" ballots="172887" overvotes="76" undervotes="11126" numVoters="161230" pushContests="0" />
+      <contest contestId="25" ballots="19623" overvotes="0" undervotes="3315" numVoters="16308" pushContests="0" />
+      <contest contestId="13" ballots="109800" overvotes="18" undervotes="6807" numVoters="102453" pushContests="0" />
+      <contest contestId="5" ballots="173964" overvotes="18" undervotes="4295" numVoters="169129" pushContests="0" />
+      <contest contestId="59" ballots="13719" overvotes="2" undervotes="2256" numVoters="11463" pushContests="0" />
+      <contest contestId="39" ballots="11611" overvotes="0" undervotes="2615" numVoters="8996" pushContests="0" />
+      <contest contestId="33" ballots="25876" overvotes="2" undervotes="5678" numVoters="20198" pushContests="0" />
+      <contest contestId="53" ballots="18456" overvotes="1" undervotes="4242" numVoters="14214" pushContests="0" />
+      <contest contestId="45" ballots="8922" overvotes="0" undervotes="1303" numVoters="7619" pushContests="0" />
+      <contest contestId="71" ballots="173964" overvotes="36" undervotes="11179" numVoters="162245" pushContests="0" />
+      <contest contestId="17" ballots="19623" overvotes="0" undervotes="3676" numVoters="15947" pushContests="0" />
+      <contest contestId="31" ballots="39106" overvotes="2" undervotes="4672" numVoters="33894" pushContests="0" />
+      <contest contestId="11" ballots="173964" overvotes="50" undervotes="12248" numVoters="161176" pushContests="0" />
+      <contest contestId="74" ballots="35611" overvotes="5" undervotes="6063" numVoters="29548" pushContests="0" />
+      <contest contestId="57" ballots="11530" overvotes="3" undervotes="2724" numVoters="8806" pushContests="0" />
+      <contest contestId="37" ballots="8864" overvotes="0" undervotes="1737" numVoters="7127" pushContests="0" />
+      <contest contestId="51" ballots="11684" overvotes="0" undervotes="1912" numVoters="9232" pushContests="0" />
+   </conteststats>
+   <results>
+      <res contId="63" chId="61" wrInd="0" prtId="0" vot="8054" />
+      <res contId="65" chId="62" wrInd="0" prtId="0" vot="5735" />
+      <res contId="43" chId="173" wrInd="0" prtId="0" vot="44" />
+      <res contId="21" chId="166" wrInd="0" prtId="0" vot="591" />
+      <res contId="72" chId="152" wrInd="0" prtId="0" vot="74975" />
+      <res contId="19" chId="28" wrInd="0" prtId="0" vot="92644" />
+      <res contId="11" chId="164" wrInd="0" prtId="0" vot="296" />
+      <res contId="71" chId="149" wrInd="0" prtId="0" vot="129849" />
+      <res contId="37" chId="133" wrInd="0" prtId="0" vot="111" />
+      <res contId="19" chId="134" wrInd="0" prtId="0" vot="17672" />
+      <res contId="27" chId="119" wrInd="0" prtId="0" vot="95" />
+      <res contId="70" chId="147" wrInd="0" prtId="0" vot="107804" />
+      <res contId="69" chId="161" wrInd="0" prtId="0" vot="2733" />
+      <res contId="7" chId="9" wrInd="0" prtId="0" vot="136234" />
+      <res contId="11" chId="145" wrInd="0" prtId="0" vot="3867" />
+      <res contId="57" chId="126" wrInd="0" prtId="0" vot="251" />
+      <res contId="43" chId="45" wrInd="0" prtId="0" vot="730" />
+      <res contId="35" chId="41" wrInd="0" prtId="0" vot="6820" />
+      <res contId="47" chId="50" wrInd="0" prtId="0" vot="5083" />
+      <res contId="74" chId="155" wrInd="0" prtId="0" vot="23325" />
+      <res contId="72" chId="151" wrInd="0" prtId="0" vot="89398" />
+      <res contId="39" chId="43" wrInd="0" prtId="0" vot="8842" />
+      <res contId="67" chId="172" wrInd="0" prtId="0" vot="3635" />
+      <res contId="27" chId="33" wrInd="0" prtId="0" vot="5761" />
+      <res contId="5" chId="6" wrInd="0" prtId="0" vot="137477" />
+      <res contId="55" chId="54" wrInd="0" prtId="0" vot="8197" />
+      <res contId="41" chId="44" wrInd="0" prtId="0" vot="11231" />
+      <res contId="15" chId="23" wrInd="0" prtId="0" vot="47528" />
+      <res contId="73" chId="154" wrInd="0" prtId="0" vot="47213" />
+      <res contId="19" chId="170" wrInd="0" prtId="0" vot="286" />
+      <res contId="71" chId="150" wrInd="0" prtId="0" vot="32855" />
+      <res contId="17" chId="171" wrInd="0" prtId="0" vot="340" />
+      <res contId="61" chId="165" wrInd="0" prtId="0" vot="128" />
+      <res contId="13" chId="137" wrInd="0" prtId="0" vot="14985" />
+      <res contId="11" chId="13" wrInd="0" prtId="0" vot="113503" />
+      <res contId="11" chId="138" wrInd="0" prtId="0" vot="35270" />
+      <res contId="57" chId="55" wrInd="0" prtId="0" vot="8552" />
+      <res contId="49" chId="51" wrInd="0" prtId="0" vot="9255" />
+      <res contId="1" chId="2" wrInd="0" prtId="0" vot="138775" />
+      <res contId="23" chId="117" wrInd="0" prtId="0" vot="909" />
+      <res contId="13" chId="21" wrInd="0" prtId="0" vot="87615" />
+      <res contId="7" chId="169" wrInd="0" prtId="0" vot="316" />
+      <res contId="1" chId="167" wrInd="0" prtId="0" vot="365" />
+      <res contId="45" chId="159" wrInd="0" prtId="0" vot="105" />
+      <res contId="21" chId="29" wrInd="0" prtId="0" vot="24677" />
+      <res contId="55" chId="74" wrInd="0" prtId="0" vot="90" />
+      <res contId="59" chId="56" wrInd="0" prtId="0" vot="11315" />
+      <res contId="23" chId="31" wrInd="0" prtId="0" vot="39729" />
+      <res contId="67" chId="63" wrInd="0" prtId="0" vot="132644" />
+      <res contId="11" chId="12" wrInd="0" prtId="0" vot="6197" />
+      <res contId="25" chId="32" wrInd="0" prtId="0" vot="16027" />
+      <res contId="29" chId="100" wrInd="0" prtId="0" vot="499" />
+      <res contId="65" chId="122" wrInd="0" prtId="0" vot="98" />
+      <res contId="1" chId="143" wrInd="0" prtId="0" vot="2416" />
+      <res contId="9" chId="174" wrInd="0" prtId="0" vot="759" />
+      <res contId="35" chId="127" wrInd="0" prtId="0" vot="165" />
+      <res contId="5" chId="162" wrInd="0" prtId="0" vot="289" />
+      <res contId="33" chId="40" wrInd="0" prtId="0" vot="19678" />
+      <res contId="1" chId="1" wrInd="0" prtId="0" vot="30278" />
+      <res contId="73" chId="153" wrInd="0" prtId="0" vot="114421" />
+      <res contId="53" chId="53" wrInd="0" prtId="0" vot="13938" />
+      <res contId="9" chId="144" wrInd="0" prtId="0" vot="20267" />
+      <res contId="17" chId="26" wrInd="0" prtId="0" vot="15607" />
+      <res contId="15" chId="168" wrInd="0" prtId="0" vot="234" />
+      <res contId="51" chId="70" wrInd="0" prtId="0" vot="139" />
+      <res contId="33" chId="71" wrInd="0" prtId="0" vot="518" />
+      <res contId="15" chId="135" wrInd="0" prtId="0" vot="11836" />
+      <res contId="37" chId="42" wrInd="0" prtId="0" vot="7016" />
+      <res contId="75" chId="157" wrInd="0" prtId="0" vot="24104" />
+      <res contId="41" chId="99" wrInd="0" prtId="0" vot="279" />
+      <res contId="9" chId="11" wrInd="0" prtId="0" vot="137147" />
+      <res contId="39" chId="116" wrInd="0" prtId="0" vot="154" />
+      <res contId="53" chId="93" wrInd="0" prtId="0" vot="275" />
+      <res contId="63" chId="105" wrInd="0" prtId="0" vot="136" />
+      <res contId="75" chId="158" wrInd="0" prtId="0" vot="3909" />
+      <res contId="11" chId="146" wrInd="0" prtId="0" vot="2496" />
+      <res contId="7" chId="139" wrInd="0" prtId="0" vot="23626" />
+      <res contId="51" chId="52" wrInd="0" prtId="0" vot="9549" />
+      <res contId="47" chId="69" wrInd="0" prtId="0" vot="72" />
+      <res contId="45" chId="48" wrInd="0" prtId="0" vot="7514" />
+      <res contId="43" chId="47" wrInd="0" prtId="0" vot="5729" />
+      <res contId="69" chId="65" wrInd="0" prtId="0" vot="133266" />
+      <res contId="13" chId="160" wrInd="0" prtId="0" vot="344" />
+      <res contId="29" chId="34" wrInd="0" prtId="0" vot="24130" />
+      <res contId="49" chId="107" wrInd="0" prtId="0" vot="173" />
+      <res contId="31" chId="163" wrInd="0" prtId="0" vot="408" />
+      <res contId="61" chId="59" wrInd="0" prtId="0" vot="12364" />
+      <res contId="70" chId="148" wrInd="0" prtId="0" vot="58725" />
+      <res contId="25" chId="108" wrInd="0" prtId="0" vot="281" />
+      <res contId="31" chId="38" wrInd="0" prtId="0" vot="33940" />
+      <res contId="7" chId="10" wrInd="0" prtId="0" vot="7783" />
+      <res contId="59" chId="120" wrInd="0" prtId="0" vot="146" />
+      <res contId="5" chId="140" wrInd="0" prtId="0" vot="31870" />
+      <res contId="74" chId="156" wrInd="0" prtId="0" vot="6218" />
+   </results>
+   <pollprogress>
+      <area areaId="1" reported="275" total="275" />
+      <area areaId="2" reported="275" total="275" />
+      <area areaId="3" reported="189" total="189" />
+      <area areaId="4" reported="85" total="86" />
+      <area areaId="5" reported="35" total="35" />
+      <area areaId="6" reported="194" total="195" />
+      <area areaId="7" reported="45" total="45" />
+      <area areaId="8" reported="82" total="83" />
+      <area areaId="9" reported="73" total="73" />
+      <area areaId="10" reported="37" total="37" />
+      <area areaId="11" reported="8" total="8" />
+      <area areaId="12" reported="39" total="39" />
+      <area areaId="13" reported="35" total="35" />
+      <area areaId="14" reported="14" total="14" />
+      <area areaId="15" reported="11" total="11" />
+      <area areaId="16" reported="16" total="16" />
+      <area areaId="17" reported="19" total="20" />
+      <area areaId="18" reported="19" total="19" />
+      <area areaId="19" reported="20" total="20" />
+      <area areaId="20" reported="17" total="17" />
+      <area areaId="21" reported="18" total="18" />
+      <area areaId="22" reported="17" total="17" />
+      <area areaId="23" reported="22" total="22" />
+      <area areaId="24" reported="16" total="16" />
+      <area areaId="25" reported="19" total="19" />
+      <area areaId="26" reported="19" total="19" />
+      <area areaId="27" reported="19" total="19" />
+      <area areaId="28" reported="15" total="15" />
+      <area areaId="29" reported="13" total="13" />
+      <area areaId="30" reported="274" total="275" />
+      <area areaId="31" reported="274" total="275" />
+      <area areaId="32" reported="274" total="275" />
+      <area areaId="33" reported="54" total="54" />
+   </pollprogress>
+   <writeins />
+   <electorgroups>
+      <group groupId="1" isTop="1" name="Default" abbreviation="Def" />
+      <group groupId="2" isTop="0" name="CARD 2" abbreviation="C2" />
+   </electorgroups>
+   <contestgroups>
+      <cg conId="1" egId="1" />
+      <cg conId="5" egId="1" />
+      <cg conId="7" egId="1" />
+      <cg conId="9" egId="1" />
+      <cg conId="11" egId="1" />
+      <cg conId="13" egId="1" />
+      <cg conId="15" egId="1" />
+      <cg conId="17" egId="1" />
+      <cg conId="19" egId="1" />
+      <cg conId="21" egId="1" />
+      <cg conId="23" egId="1" />
+      <cg conId="25" egId="1" />
+      <cg conId="27" egId="1" />
+      <cg conId="29" egId="1" />
+      <cg conId="31" egId="1" />
+      <cg conId="33" egId="1" />
+      <cg conId="35" egId="1" />
+      <cg conId="37" egId="1" />
+      <cg conId="39" egId="1" />
+      <cg conId="41" egId="1" />
+      <cg conId="43" egId="1" />
+      <cg conId="45" egId="1" />
+      <cg conId="47" egId="1" />
+      <cg conId="49" egId="1" />
+      <cg conId="51" egId="1" />
+      <cg conId="53" egId="1" />
+      <cg conId="55" egId="1" />
+      <cg conId="57" egId="1" />
+      <cg conId="59" egId="1" />
+      <cg conId="61" egId="1" />
+      <cg conId="63" egId="1" />
+      <cg conId="65" egId="1" />
+      <cg conId="67" egId="1" />
+      <cg conId="69" egId="1" />
+      <cg conId="70" egId="1" />
+      <cg conId="71" egId="1" />
+      <cg conId="72" egId="2" />
+      <cg conId="73" egId="2" />
+      <cg conId="74" egId="2" />
+      <cg conId="75" egId="2" />
+   </contestgroups>
+</ExportName>

--- a/docroot/themes/custom/bos_theme/dist/js/all.js
+++ b/docroot/themes/custom/bos_theme/dist/js/all.js
@@ -20,36 +20,11 @@
 })(jQuery, Drupal, this, this.document);
 
 /**
- * Unofficial election results
- * Select Option follow link url in option value
- * 10/19/2022
- *
- */
-(function ($, Drupal, window, document) {
-  'use strict';
-  $(function() {
-    $('#election_results').on('change', function() {
-      var url = $(this).val(); // get selected value
-      $('div.es_hide').hide();
-      $("div.es_hide").parents('.election_results_parent').hide();
-      $("#"+url).show();
-      $("#"+url+".es_hide").parents('.election_results_parent').show();
-      if (url === "all") {
-        $('div.es_hide').show();
-        $("div.es_hide").parents('.election_results_parent').show();
-      }
-      return false;
-    });
-  });
-})(jQuery, Drupal, this, this.document);
-
-/**
  * @file
  * Drawer behaviors.
  *
  * Adds functionality for drawers across the site.
  */
-
 (function ($, Drupal, window, document) {
 
   'use strict';


### PR DESCRIPTION
- Sorts the order of contests by sort order provided in import file (this will now align with the order in the selectbox).
- Sorting is done by javascript in module level js script. Also removed the filtering js from all.js into the same module-level js file. This js file added to the module library so that code will only be included when the election_report node is rendered (election_report node is typically embedded within an election_card paragraph which is in turn embedded within an article node).
- Background striping has been updated along with the filtering activity, by adding/removing css classes directly and not using n-child css rules (which can get confused when jquery moves elements on the page).