### PR TITLE
(develop) election history wont get overwritten on deploy DIG-1435

### DIFF
--- a/config/acquia_dev/config_ignore.settings.yml
+++ b/config/acquia_dev/config_ignore.settings.yml
@@ -13,3 +13,4 @@ ignored_config_entities:
   - salesforce.salesforce_auth.dnd_prod
   - salesforce.settings
   - slackposter.settings
+  - node_elections.settings

--- a/config/acquia_stage/config_ignore.settings.yml
+++ b/config/acquia_stage/config_ignore.settings.yml
@@ -13,3 +13,4 @@ ignored_config_entities:
   - salesforce.salesforce_auth.dnd_prod
   - salesforce.settings
   - slackposter.settings
+  - node_elections.settings

--- a/config/local/config_ignore.settings.yml
+++ b/config/local/config_ignore.settings.yml
@@ -13,3 +13,4 @@ ignored_config_entities:
   - salesforce.salesforce_auth.dnd_prod
   - salesforce.settings
   - slackposter.settings
+  - node_elections.settings


### PR DESCRIPTION
This can wait until next deploy cycle as it only affects non-prod environments.