### PR TITLE
(develop) DIG-1770 (hotfix) JQuery missing modules

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -78,7 +78,9 @@ module:
   inline_entity_form: 0
   jquery_ui: 0
   jquery_ui_accordion: 0
+  jquery_ui_autocomplete: 0
   jquery_ui_datepicker: 0
+  jquery_ui_menu: 0
   jquery_ui_slider: 0
   jquery_ui_touch_punch: 0
   jsonapi: 0


### PR DESCRIPTION
Looks like at some point these got split into separate modules and geolocation has a dependency on them