### PR TITLE
(develop) Adjust order of contact information in event sidebar - hotfix

### DIFF
--- a/docroot/modules/custom/bos_content/modules/node_event/templates/node--event.html.twig
+++ b/docroot/modules/custom/bos_content/modules/node_event/templates/node--event.html.twig
@@ -168,6 +168,12 @@
               </li>
             {% endif %}
 
+            {% if content.field_event_contact %}
+              <li class="dl-i evt-sb-i">
+                {{ content.field_event_contact }}
+              </li>
+            {% endif %}
+
             {% if content.field_email["#items"] %}
               <li class="sb-i evt-sb-i">
                 {{ content.field_email }}
@@ -183,12 +189,6 @@
             {% if content.cost %}
               <li class="dl-i evt-sb-i">
                 {{ content.cost }}
-              </li>
-            {% endif %}
-
-            {% if content.field_event_contact %}
-              <li class="dl-i evt-sb-i">
-                {{ content.field_event_contact }}
               </li>
             {% endif %}
 
@@ -270,6 +270,12 @@
           </li>
         {% endif %}
 
+        {% if content.field_event_contact %}
+          <li class="dl-i evt-sb-i">
+            {{ content.field_event_contact }}
+          </li>
+        {% endif %}
+
         {% if content.field_email["#items"] %}
           <li class="sb-i evt-sb-i">
             {{ content.field_email }}
@@ -285,12 +291,6 @@
         {% if content.cost %}
           <li class="dl-i evt-sb-i">
             {{ content.cost }}
-          </li>
-        {% endif %}
-
-        {% if content.field_event_contact %}
-          <li class="dl-i evt-sb-i">
-            {{ content.field_event_contact }}
           </li>
         {% endif %}
 


### PR DESCRIPTION
DIG-2060 - [Adjust order of contact information in event sidebar; move down 'email' field](https://bostondoit.atlassian.net/browse/DIG-2060)