### PR TITLE
(develop) Ass phone number as option to Boston.gov contact form

### DIFF
--- a/docroot/themes/custom/bos_theme/templates/snippets/contactFormTemplate.html.twig
+++ b/docroot/themes/custom/bos_theme/templates/snippets/contactFormTemplate.html.twig
@@ -35,7 +35,7 @@
                                 </div>
                                 <div class="txt m-b300">
                                   <label for="contact-phone" class="txt-l txt-l--mt000">Phone</label>
-                                  <input id="contact-phone" name="email[phone]" type="text" placeholder="000-000-0000" class="txt-f bos-contact-phone" size="10" value="">
+                                  <input id="contact-phone" name="email[phone]" type="text" placeholder="999-999-9999" class="txt-f bos-contact-phone" size="10" value="">
                                 </div>
                                 <div class="txt m-b300">
                                     <label for="contact-subject" class="txt-l txt-l--mt000">Subject</label>

--- a/docroot/themes/custom/bos_theme/templates/snippets/contactFormTemplate.html.twig
+++ b/docroot/themes/custom/bos_theme/templates/snippets/contactFormTemplate.html.twig
@@ -34,6 +34,10 @@
                                   <input id="contact-address-two" name="email2[from_address]" type="text" placeholder="re-enter email@address.com" class="txt-f bos-contact-email2" value="">
                                 </div>
                                 <div class="txt m-b300">
+                                  <label for="contact-phone" class="txt-l txt-l--mt000">Phone</label>
+                                  <input id="contact-phone" name="email[phone]" type="text" placeholder="000-000-0000" class="txt-f bos-contact-phone" size="10" value="">
+                                </div>
+                                <div class="txt m-b300">
                                     <label for="contact-subject" class="txt-l txt-l--mt000">Subject</label>
                                     <input id="contact-subject" name="email[subject]" type="text" class="txt-f bos-contact-subject" size="10" value="">
                                 </div>


### PR DESCRIPTION
DIG-2527:[ Add phone number as option in Boston.gov contact form](https://bostondoit.atlassian.net/browse/DIG-2527)