### PR TITLE
(develop) Blue text not appearing on white background in components (hotfix)

### DIFF
--- a/docroot/modules/custom/bos_components/css/component-theme.css
+++ b/docroot/modules/custom/bos_components/css/component-theme.css
@@ -436,8 +436,13 @@
 .paragraphs-item-3-column-w-image.b--b h5,
 .paragraphs-item-3-column-w-image.b--b h6,
 .paragraphs-item-3-column-w-image.b--b ol,
-.paragraphs-item-3-column-w-image.b--b .supporting-text {
+.paragraphs-item-3-column-w-image.b--b .supporting-text,
+.b--b .paragraphs-item-text-three-column ol,
+.b--b .paragraphs-item-text-three-column li {
   color: #FFFFFF;
+}
+.b--b .paragraphs-item-text-three-column ul li {
+  background-image: url(https://patterns.boston.gov/images/global/icons/ul-bullet-white.svg);
 }
 
 .paragraphs-item-3-column-w-image.b--b .column-wrapper {


### PR DESCRIPTION
DIG-3979 Blue text not appearing on white background in components