### PR TITLE
DIG-4170 Listing 'Intro' class text

### DIFF
--- a/docroot/modules/custom/bos_components/css/component-theme.css
+++ b/docroot/modules/custom/bos_components/css/component-theme.css
@@ -654,7 +654,7 @@ article .paragraphs-item-3-column-w-image.b--w ul li {
 
 /* ToDo global changes for theme component */
 
-.b--b .t--intro, .b--b .supporting-text, .b--b address, .b--b h1, .b--b h2, .b--b h3, .b--b h4, .b--b h5, .b--b h6 {
+.b--b .t--intro, .b--b .supporting-text, .b--b address, .b--b h1, .b--b h2, .b--b h3, .b--b h4, .b--b h5, .b--b h6, .b--b ol {
   color: #ffffff;
 }
 


### PR DESCRIPTION
DIG-4170 Listing 'Intro' class text not appearing in blue background of 'formatted text' component