### PR TITLE
(develop) BH admin page sf sync improvements

### DIFF
--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/node_buildinghousing.links.menu.yml
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/node_buildinghousing.links.menu.yml
@@ -1,6 +1,6 @@
 salesforce.admin_config_boston:
   route_name: salesforce.admin_config_boston
-  parent: salesforce.admin_config_salesforce
+  parent: bos_core.admin
   title: Building Housing Utilities
   description: 'City of Boston for Building Housing integration of Salesforce Suite.'
   weight: -100

--- a/docroot/modules/custom/bos_content/modules/node_buildinghousing/node_buildinghousing.routing.yml
+++ b/docroot/modules/custom/bos_content/modules/node_buildinghousing/node_buildinghousing.routing.yml
@@ -4,5 +4,5 @@ salesforce.admin_config_boston:
     _form: '\Drupal\node_buildinghousing\Form\SalesforceSyncSettings'
     _title: 'City of Boston: Building Housing SF Utilities'
   requirements:
-    _permission: 'View Salesforce mapping'
+    _permission: 'edit any bh_project content'
 


### PR DESCRIPTION
chore: BH admin page sf sync improvements
- Sets permissions on the SF/BH Admin page, 
- improves page layout, 
- adds resilience to SF connectivity issues 
- relocates config page link in menu system.