### PR TITLE
DIG-4874 Fix Google Translate Spanish translation error for email addresses

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_sidebar/templates/paragraph--sidebar-item-w-icon.html.twig
+++ b/docroot/modules/custom/bos_components/modules/bos_sidebar/templates/paragraph--sidebar-item-w-icon.html.twig
@@ -35,7 +35,7 @@
       </div>
       {#{%  endif %}#}
       {% if content.field_sidebar_text %}
-         <div class="sb-b {{ classes.body }}">
+         <div class="sb-b {{ classes.body }}notranslate">
             {% if phone  %}
                <a href="tel:{{ content.field_sidebar_text }}">{{ content.field_sidebar_text }}</a>
             {% else %}


### PR DESCRIPTION
Fix Google Translate Spanish translation error for email addresses