### PR TITLE
(UAT) DIG-4627 Must add theme templates when cache globally rebuilt

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_search/bos_search.module
+++ b/docroot/modules/custom/bos_components/modules/bos_search/bos_search.module
@@ -36,11 +36,9 @@ function bos_search_theme($existing, $type, $theme, $path):array  {
 
   ];
 
-  // If needed, discover dynamic aisearch templates and themes from this module
-  if (AiSearch::isBosSearchThemed()) {
-    _bos_search_autodiscover_theme($output);
-    _bos_search_snippet_theme($output);
-  }
+  // Discover dynamic aisearch templates and themes from this module
+  _bos_search_autodiscover_theme($output);
+  _bos_search_snippet_theme($output);
 
   // Load component themes.
   // TODO: This should be moved to the themes hook_theme function.
@@ -51,7 +49,9 @@ function bos_search_theme($existing, $type, $theme, $path):array  {
 }
 
 function bos_search_theme_suggestions_alter(array &$suggestions, array &$variables, $hook):void  {
-  _search_form_suggestions($suggestions, $variables, $hook);
+  if (!AiSearch::isBosSearchThemed()) {
+    _search_form_suggestions($suggestions, $variables, $hook);
+  }
 }
 
 function bos_search_preprocess_search_bar(&$variables):void  {

--- a/docroot/modules/custom/bos_components/modules/bos_search/includes/aisearch_form_theme.inc
+++ b/docroot/modules/custom/bos_components/modules/bos_search/includes/aisearch_form_theme.inc
@@ -158,10 +158,6 @@ function _bos_search_preprocess_input(&$variables, $hook):void  {
  */
 function _search_form_suggestions(array &$suggestions, array &$variables, $hook):void  {
 
-  if (!AiSearch::isBosSearchThemed()) {
-    return;
-  }
-
   if (!empty($variables["element"])) {
     // Get the form theme being used by the active preset, or else use 'default'.
     $preset = AiSearch::getPreset();

--- a/docroot/modules/custom/bos_components/modules/bos_search/src/AiSearch.php
+++ b/docroot/modules/custom/bos_components/modules/bos_search/src/AiSearch.php
@@ -187,7 +187,7 @@ class AiSearch {
     }
 
     // Don't appear to need the bos_search theme, return false.
-    \Drupal::logger('search')->log("Not AISearch Themed");
+    \Drupal::logger('search')->info("Not AISearch Themed");
     return FALSE;
   }
 


### PR DESCRIPTION
The way this was being done before took advantage of the fact that on the local dev environment, the service settings `twig.config.cache=false` and `twig.config.autoreload=true` allowed twig template caches to be rebuilt each time a page was rendered,  On Acquia environments, these settings are flipped and the template caches are only loaded when a cache-reset is done. Hence the templates were not loading and the theme was not being applied on Acquia, while it was on local.