### PR TITLE
(dev) DIG-5067-Updated-Libraries-YML-to-Include-All-Bundles

### DIFF
--- a/docroot/modules/custom/bos_components/modules/bos_web_app/apps/metrolist/metrolist.libraries.yml
+++ b/docroot/modules/custom/bos_components/modules/bos_web_app/apps/metrolist/metrolist.libraries.yml
@@ -1,6 +1,12 @@
 metrolist:
-  version: 4.2.20240925328
+  version: 4.3.20240925328
   js:
     dist/index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
+    dist/1.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
+    dist/2.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
+    dist/3.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
+    dist/4.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
+    dist/5.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
+    dist/6.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
   dependencies:
     - core/drupalSettings

--- a/docroot/modules/custom/bos_components/modules/bos_web_app/apps/metrolist/metrolist.libraries.yml
+++ b/docroot/modules/custom/bos_components/modules/bos_web_app/apps/metrolist/metrolist.libraries.yml
@@ -1,5 +1,5 @@
 metrolist:
-  version: 4.3.20240925328
+  version: 4.2.202409260926
   js:
     dist/index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}
     dist/1.index.bundle.js: { preprocess: false, attributes: {type: text/javascript}}


### PR DESCRIPTION
Potential fix to bundles not loading correctly in previously deployed version of dev as well as missing css around filter panel elements.